### PR TITLE
webclient - index into iceservers

### DIFF
--- a/Samples/Client/WebClient/index.html
+++ b/Samples/Client/WebClient/index.html
@@ -66,8 +66,8 @@
                             console.log("Identity management returned", data);
 
                             pcConfig = pcConfigDynamic;
-                            pcConfig.iceServers.username = data.username;
-                            pcConfig.iceServers.credential = data.password;
+                            pcConfig.iceServers[0].username = data.username;
+                            pcConfig.iceServers[0].credential = data.password;
                         }
                     };
                     loginRequest.open("GET", identityManagementConfig.turnCredsUrl, true);


### PR DESCRIPTION
There was an issue with the credentials for dynamic ice configuration - instead of setting the username and credential directly on the `iceServers` array, we should set them on the item in the array (aka `[0]`)