### PR TITLE
fix long running signaling sessions timeout (#45)

### DIFF
--- a/Libraries/SignalingClient/inc/peer_connection_client.h
+++ b/Libraries/SignalingClient/inc/peer_connection_client.h
@@ -135,7 +135,7 @@ protected:
 
 	int GetResponseStatus(const std::string& response);
 
-	bool ParseServerResponse(const std::string& response, size_t content_length,
+	int ParseServerResponse(const std::string& response, size_t content_length,
 							size_t* peer_id, size_t* eoh);
 
 	void OnClose(rtc::AsyncSocket* socket, int err);

--- a/Libraries/SignalingClient/inc/peer_connection_client.h
+++ b/Libraries/SignalingClient/inc/peer_connection_client.h
@@ -140,8 +140,6 @@ protected:
 
 	void OnClose(rtc::AsyncSocket* socket, int err);
 
-	void OnSignalingServerClose(rtc::AsyncSocket* socket, int err);
-
 	void OnHeartbeatGetClose(rtc::AsyncSocket* socket, int err);
 
 	void OnResolveResult(rtc::AsyncResolverInterface* resolver);

--- a/Libraries/SignalingClient/inc/peer_connection_client.h
+++ b/Libraries/SignalingClient/inc/peer_connection_client.h
@@ -142,6 +142,8 @@ protected:
 
 	void OnSignalingServerClose(rtc::AsyncSocket* socket, int err);
 
+	void OnHeartbeatGetClose(rtc::AsyncSocket* socket, int err);
+
 	void OnResolveResult(rtc::AsyncResolverInterface* resolver);
 
 	std::string PrepareRequest(const std::string& method, const std::string& fragment, std::map<std::string, std::string> headers);

--- a/Libraries/SignalingClient/src/peer_connection_client.cpp
+++ b/Libraries/SignalingClient/src/peer_connection_client.cpp
@@ -713,10 +713,6 @@ void PeerConnectionClient::OnMessage(rtc::Message* msg)
 		{
 			// but note that closing the heartbeat retriggers this message...
 			heartbeat_get_->Close();
-
-			// so we actually just return here, and the next iteration will execute connect
-			// since the socket will then be closed.
-			return;
 		}
 
 		heartbeat_get_->Connect(server_address_);

--- a/Libraries/SignalingClient/src/peer_connection_client.cpp
+++ b/Libraries/SignalingClient/src/peer_connection_client.cpp
@@ -711,7 +711,6 @@ void PeerConnectionClient::OnMessage(rtc::Message* msg)
 		// if the socket is still open, close it and then reconnect to trigger the beat...
 		if (heartbeat_get_->GetState() != rtc::Socket::ConnState::CS_CLOSED)
 		{
-			// but note that closing the heartbeat retriggers this message...
 			heartbeat_get_->Close();
 		}
 


### PR DESCRIPTION
+ fixes #45 
+ adds socket close retry logic to heartbeat socket (technically unrelated to the issue, but good to have so including here)