### PR TITLE
add support for a logging callback in unity server plugin

### DIFF
--- a/Plugins/UnityServerPlugin/StreamingUnityServerPlugin.cpp
+++ b/Plugins/UnityServerPlugin/StreamingUnityServerPlugin.cpp
@@ -110,14 +110,14 @@ void InitWebRTC()
 	rtc::Win32Thread w32_thread;
 	rtc::ThreadManager::Instance()->SetCurrentThread(&w32_thread);
 	rtc::InitializeSSL();
-	
+
 	PeerConnectionClient client;
 
 	wnd = new DefaultMainWindow(FLAG_server, FLAG_port, FLAG_autoconnect, FLAG_autocall,
 		true, 1280, 720);
-	
+
 	wnd->Create();
-	
+
 	// Try parsing config file.
 	std::string configFilePath = webrtc::ExePath("webrtcConfig.json");
 	std::ifstream webrtcConfigFile(configFilePath);
@@ -151,7 +151,7 @@ void InitWebRTC()
 	client.SetHeartbeatMs(heartbeat);
 
 	s_conductor = new rtc::RefCountedObject<Conductor>(&client, wnd, &FrameUpdate, &InputUpdate, g_videoHelper);
-	
+
 	if (s_conductor != nullptr)
 	{
 		MainWindowCallback *callback = s_conductor;
@@ -185,14 +185,16 @@ static void UNITY_INTERFACE_API OnEncode(int eventID)
 	ULOG(INFO, __FUNCTION__);
 
 	if (s_Context)
-    {
+	{
+		ULOG(INFO, "s_Context is ~NULL");
+
 		if (s_frameBuffer == nullptr)
 		{
 			ID3D11RenderTargetView* rtv(nullptr);
 			ID3D11DepthStencilView* depthStencilView(nullptr);
 
 			s_Context->OMGetRenderTargets(1, &rtv, &depthStencilView);
-			
+
 			if (rtv)
 			{
 				rtv->GetResource(reinterpret_cast<ID3D11Resource**>(&s_frameBuffer));
@@ -201,43 +203,43 @@ static void UNITY_INTERFACE_API OnEncode(int eventID)
 				D3D11_TEXTURE2D_DESC desc;
 
 				s_frameBuffer->GetDesc(&desc);
-					
+
 				g_videoHelper->Initialize(s_frameBuffer, desc.Format, desc.Width, desc.Height);
-				
+
 				s_frameBuffer->Release();
-				
+
 				messageThread = new std::thread(InitWebRTC);
 			}
 		}
 
-        return;
-    }
+		return;
+	}
 }
 
 extern "C" void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType eventType)
 {
 	ULOG(INFO, __FUNCTION__);
 
-    switch (eventType)
-    {
-        case kUnityGfxDeviceEventInitialize:
-        {
-            s_DeviceType = s_Graphics->GetRenderer();
-            s_Device = s_UnityInterfaces->Get<IUnityGraphicsD3D11>()->GetDevice();
-            s_Device->GetImmediateContext(&s_Context);
-			
-			break;
-        }
+	switch (eventType)
+	{
+	case kUnityGfxDeviceEventInitialize:
+	{
+		s_DeviceType = s_Graphics->GetRenderer();
+		s_Device = s_UnityInterfaces->Get<IUnityGraphicsD3D11>()->GetDevice();
+		s_Device->GetImmediateContext(&s_Context);
 
-        case kUnityGfxDeviceEventShutdown:
-        {
-			s_Context.Reset();
-            s_Device.Reset();
-            s_DeviceType = kUnityGfxRendererNull;
+		break;
+	}
 
-            break;
-        }
-    }
+	case kUnityGfxDeviceEventShutdown:
+	{
+		s_Context.Reset();
+		s_Device.Reset();
+		s_DeviceType = kUnityGfxRendererNull;
+
+		break;
+	}
+	}
 }
 
 
@@ -247,20 +249,20 @@ extern "C" void	UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnit
 	ULOG(INFO, __FUNCTION__);
 
 #if SHOW_CONSOLE
-    AllocConsole();
-    FILE* out(nullptr);
-    freopen_s(&out, "CONOUT$", "w", stdout);
+	AllocConsole();
+	FILE* out(nullptr);
+	freopen_s(&out, "CONOUT$", "w", stdout);
 
-    std::cout << "Console open..." << std::endl;
+	std::cout << "Console open..." << std::endl;
 	ULOG(INFO, "Console open...")
 #endif
-	
-    s_UnityInterfaces = unityInterfaces;
-    s_Graphics = s_UnityInterfaces->Get<IUnityGraphics>();
-    s_Graphics->RegisterDeviceEventCallback(OnGraphicsDeviceEvent);
 
-    // Run OnGraphicsDeviceEvent(initialize) manually on plugin load
-    OnGraphicsDeviceEvent(kUnityGfxDeviceEventInitialize);
+		s_UnityInterfaces = unityInterfaces;
+	s_Graphics = s_UnityInterfaces->Get<IUnityGraphics>();
+	s_Graphics->RegisterDeviceEventCallback(OnGraphicsDeviceEvent);
+
+	// Run OnGraphicsDeviceEvent(initialize) manually on plugin load
+	OnGraphicsDeviceEvent(kUnityGfxDeviceEventInitialize);
 
 	// Creates and initializes the video helper library.
 	g_videoHelper = new VideoHelper(s_Device.Get(), s_Context.Get());
@@ -279,7 +281,7 @@ extern "C" __declspec(dllexport) void Close()
 		callback->Close();
 
 		s_conductor = nullptr;
-		
+
 		rtc::CleanupSSL();
 
 		s_closing = true;
@@ -291,7 +293,7 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
 {
 	ULOG(INFO, __FUNCTION__);
 
-    s_Graphics->UnregisterDeviceEventCallback(OnGraphicsDeviceEvent);
+	s_Graphics->UnregisterDeviceEventCallback(OnGraphicsDeviceEvent);
 
 	Close();
 }
@@ -300,7 +302,7 @@ extern "C" UnityRenderingEvent UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetRen
 {
 	ULOG(INFO, __FUNCTION__);
 
-    return OnEncode;
+	return OnEncode;
 }
 
 extern "C" __declspec(dllexport) void SetInputDataCallback(void(__stdcall*onInputUpdate)(const char *msg))

--- a/Samples/Server/Unity-FractalStream/Assets/WebRTCServer.cs
+++ b/Samples/Server/Unity-FractalStream/Assets/WebRTCServer.cs
@@ -129,7 +129,11 @@ public class WebRTCServer : MonoBehaviour
                 var kbBody = node["body"];
                 int kbMsg = kbBody["msg"];
                 int kbWParam = kbBody["wParam"];
-                Debug.Log("Message(" + kbMsg.ToString() + ", " + kbWParam.ToString() + ")");      
+                if (Debug.isDebugBuild)
+                {
+                    Debug.Log("Message(" + kbMsg.ToString() + ", " + kbWParam.ToString() + ")");
+                }
+                    
                 break;
 
             case "mouse-event":
@@ -137,7 +141,11 @@ public class WebRTCServer : MonoBehaviour
                 int mouseMsg = mouseBody["msg"];
                 int mouseWParam = mouseBody["wParam"];
                 int mouseLParam = mouseBody["lParam"];
-                Debug.Log("Message(" + mouseMsg.ToString() + ", " + mouseWParam.ToString() + ", " + mouseLParam.ToString() + ")");
+                if (Debug.isDebugBuild)
+                {
+                    Debug.Log("Message(" + mouseMsg.ToString() + ", " + mouseWParam.ToString() + ", " + mouseLParam.ToString() + ")");
+                }
+
                 break;
 
             case "camera-transform-lookat":
@@ -168,12 +176,13 @@ public class WebRTCServer : MonoBehaviour
                 break;
 
             default:
-                Debug.Log("InputData(" + val + ")");
-                Debug.Log("");
-
-                foreach (var child in node.Children)
+                if (Debug.isDebugBuild)
                 {
-                    Debug.Log(child.ToString());
+                    Debug.Log("InputData(" + val + ")");
+                    foreach (var child in node.Children)
+                    {
+                        Debug.Log(child.ToString());
+                    }
                 }
 
                 break;
@@ -182,6 +191,9 @@ public class WebRTCServer : MonoBehaviour
 
 	void OnLog(int level, string message)
 	{
-		Debug.Log(string.Format("[{0}] : {1}", level, message));
+        if (Debug.isDebugBuild)
+        {
+            Debug.Log(string.Format("[{0}] : {1}", level, message));
+        }
 	}
 }

--- a/Samples/Server/Unity-FractalStream/Assets/WebRTCServer.cs
+++ b/Samples/Server/Unity-FractalStream/Assets/WebRTCServer.cs
@@ -6,11 +6,12 @@ using UnityEngine.Rendering;
 public class WebRTCServer : MonoBehaviour
 {
     public delegate void FPtr([MarshalAs(UnmanagedType.LPStr)]string value);
+    public delegate void LogPtr(int level, [MarshalAs(UnmanagedType.LPStr)]string value);
 
 #if (UNITY_IPHONE || UNITY_WEBGL) && !UNITY_EDITOR
 	[DllImport ("__Internal")]
 #else
-    [DllImport("StreamingUnityServerPlugin")]
+	[DllImport("StreamingUnityServerPlugin")]
 #endif
     private static extern IntPtr GetRenderEventFunc();
     
@@ -24,7 +25,14 @@ public class WebRTCServer : MonoBehaviour
 #if (UNITY_IPHONE || UNITY_WEBGL) && !UNITY_EDITOR
 	[DllImport ("__Internal")]
 #else
-    [DllImport("StreamingUnityServerPlugin")]
+	[DllImport("StreamingUnityServerPlugin")]
+#endif
+	public static extern void SetLogCallback(LogPtr cb);
+
+#if (UNITY_IPHONE || UNITY_WEBGL) && !UNITY_EDITOR
+	[DllImport ("__Internal")]
+#else
+	[DllImport("StreamingUnityServerPlugin")]
 #endif
     private static extern void Close();
     
@@ -70,8 +78,10 @@ public class WebRTCServer : MonoBehaviour
         Camera.main.AddCommandBuffer(CameraEvent.AfterEverything, cmb);
         
         FPtr cb = new FPtr(OnInputData);
+		LogPtr logCb = new LogPtr(OnLog);
 
-        SetInputDataCallback(cb);
+		SetInputDataCallback(cb);
+		SetLogCallback(logCb);
     }
 
     void Stop()
@@ -169,4 +179,9 @@ public class WebRTCServer : MonoBehaviour
                 break;
         }
     }
+
+	void OnLog(int level, string message)
+	{
+		Debug.Log(string.Format("[{0}] : {1}", level, message));
+	}
 }


### PR DESCRIPTION
debugging the unity server plugin is really complicated. This improves the situation by enabling an easy way to emit logging data from within the plugin, and handle this data in our unity scripting. 🐛 😸 