### PR TITLE
add native client auth

### DIFF
--- a/Libraries/SignalingClient/SignalingClient.vcxproj
+++ b/Libraries/SignalingClient/SignalingClient.vcxproj
@@ -103,10 +103,12 @@
   <ItemGroup>
     <ClInclude Include="inc\ssl_capable_socket.h" />
     <ClInclude Include="inc\peer_connection_client.h" />
+    <ClInclude Include="inc\turn_credential_provider.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\ssl_capable_socket.cpp" />
     <ClCompile Include="src\peer_connection_client.cpp" />
+    <ClCompile Include="src\turn_credential_provider.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="exports.props" />

--- a/Libraries/SignalingClient/SignalingClient.vcxproj.filters
+++ b/Libraries/SignalingClient/SignalingClient.vcxproj.filters
@@ -7,12 +7,21 @@
     <ClCompile Include="src\ssl_capable_socket.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="src\turn_credential_provider.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\peer_connection_client.h">
       <Filter>Headers</Filter>
     </ClInclude>
     <ClInclude Include="inc\ssl_capable_socket.h">
+      <Filter>Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\authentication_provider.h">
+      <Filter>Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\turn_credential_provider.h">
       <Filter>Headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Libraries/SignalingClient/inc/authentication_provider.h
+++ b/Libraries/SignalingClient/inc/authentication_provider.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+#include <functional>
+
+/// <summary>
+/// Represents a result from an authentication provider authenticate operation
+/// </summary>
+struct AuthenticationProviderResult
+{
+public:
+	bool successFlag;
+	std::string accessToken;
+
+};
+
+/// <summary>
+/// Base class that represents an authentication provider
+/// </summary>
+class AuthenticationProvider
+{
+public:
+	AuthenticationProvider() {}
+
+	sigslot::signal1<const AuthenticationProviderResult&> SignalAuthenticationComplete;
+
+	struct AuthenticationCompleteCallback : public sigslot::has_slots<>
+	{
+		AuthenticationCompleteCallback(const std::function<void(const AuthenticationProviderResult&)>& handler) : handler_(handler)
+		{
+		}
+
+		void Handle(const AuthenticationProviderResult& data)
+		{
+			handler_(data);
+		}
+	private:
+		std::function<void(const AuthenticationProviderResult&)> handler_;
+	};
+
+	virtual bool Authenticate() = 0;
+
+protected:
+	virtual ~AuthenticationProvider() {}
+};

--- a/Libraries/SignalingClient/inc/turn_credential_provider.h
+++ b/Libraries/SignalingClient/inc/turn_credential_provider.h
@@ -1,0 +1,74 @@
+#pragma once
+#include "webrtc/base/sigslot.h"
+#include "webrtc/base/nethelpers.h"
+#include "third_party/jsoncpp/source/include/json/json.h"
+
+#include "authentication_provider.h"
+#include "ssl_capable_socket.h"
+
+// forward decl
+class TurnCredentialProvider;
+
+struct TurnCredentials
+{
+public:
+	bool successFlag;
+	std::string username;
+	std::string password;
+private:
+	friend TurnCredentialProvider;
+	TurnCredentials() {};
+};
+
+class TurnCredentialProvider : public sigslot::has_slots<>
+{
+public:
+	enum State
+	{
+		NOT_ACTIVE = 0,
+		RESOLVING,
+		AUTHENTICATING,
+		ACTIVE
+	};
+
+	TurnCredentialProvider(const std::string& uri);
+	~TurnCredentialProvider();
+
+	sigslot::signal1<const TurnCredentials&> SignalCredentialsRetrieved;
+	
+	struct CredentialsRetrievedCallback : public sigslot::has_slots<>
+	{
+		CredentialsRetrievedCallback(const std::function<void(const TurnCredentials&)>& handler) : handler_(handler)
+		{
+		}
+
+		void Handle(const TurnCredentials& data)
+		{
+			handler_(data);
+		}
+	private:
+		std::function<void(const TurnCredentials&)> handler_;
+	};
+
+	void SetAuthenticationProvider(AuthenticationProvider* authProvider);
+
+	bool RequestCredentials();
+	
+	const State& state() const;
+
+	void OnAuthenticationComplete(const AuthenticationProviderResult& result);
+
+protected:
+	void SocketOpen(rtc::AsyncSocket* socket);
+	void SocketRead(rtc::AsyncSocket* socket);
+	void SocketClose(rtc::AsyncSocket* socket, int err);
+	void AddressResolve(rtc::AsyncResolverInterface* resolver);
+
+	rtc::SocketAddress host_;
+	std::string fragment_;
+	std::string auth_token_;
+	State state_;
+	std::unique_ptr<SslCapableSocket> socket_;
+	std::unique_ptr<AsyncResolver> resolver_;
+	AuthenticationProvider* auth_provider_;
+};

--- a/Libraries/SignalingClient/src/turn_credential_provider.cpp
+++ b/Libraries/SignalingClient/src/turn_credential_provider.cpp
@@ -1,0 +1,234 @@
+#include "turn_credential_provider.h"
+
+TurnCredentialProvider::TurnCredentialProvider(const std::string& uri)
+{
+	// take the hostname, <protocol>://<hostname>[:port]/ 
+	auto tempAuthHost = uri.substr(uri.find_first_of("://") + 3);
+	auto firstSlash = tempAuthHost.find_first_of("/");
+	auto tempFragment = tempAuthHost.substr(firstSlash);
+	tempAuthHost = tempAuthHost.substr(0, firstSlash);
+	tempAuthHost = tempAuthHost.substr(0, tempAuthHost.find_first_of(":"));
+
+	// take the /path?whaterver uri fragment
+	fragment_ = tempFragment;
+
+	auto authorityPort = std::string("https://").compare(uri.substr(0, 8)) == 0 ? 443 : 80;
+	host_ = rtc::SocketAddress(tempAuthHost, authorityPort);
+
+	// configure the thread which will be used for socket signalling. it's just some representation of
+	// the current thread (wrapped or existing)
+	auto socketThread = rtc::Thread::Current();
+	socketThread = socketThread == nullptr ? rtc::ThreadManager::Instance()->WrapCurrentThread() : socketThread;
+	socket_.reset(new SslCapableSocket(host_.family(), authorityPort == 443, socketThread));
+
+	socket_->SignalConnectEvent.connect(this, &TurnCredentialProvider::SocketOpen);
+	socket_->SignalReadEvent.connect(this, &TurnCredentialProvider::SocketRead);
+	socket_->SignalCloseEvent.connect(this, &TurnCredentialProvider::SocketClose);
+}
+
+TurnCredentialProvider::~TurnCredentialProvider()
+{
+	if (auth_provider_ != nullptr)
+	{
+		auth_provider_->SignalAuthenticationComplete.disconnect(this);
+	}
+}
+
+void TurnCredentialProvider::SetAuthenticationProvider(AuthenticationProvider* authProvider)
+{
+	auth_provider_ = authProvider;
+	auth_provider_->SignalAuthenticationComplete.connect(this, &TurnCredentialProvider::OnAuthenticationComplete);
+}
+
+bool TurnCredentialProvider::RequestCredentials()
+{
+	if (state_ != State::NOT_ACTIVE)
+	{
+		return false;
+	}
+
+	if (socket_->GetState() != rtc::Socket::CS_CLOSED)
+	{
+		if (0 != socket_->Close())
+		{
+			return false;
+		}
+	}
+
+	// if we need to resolve the ip we do that before connecting
+	if (host_.IsUnresolvedIP())
+	{
+		state_ = RESOLVING;
+		resolver_.reset(new rtc::AsyncResolver());
+		resolver_->SignalDone.connect(this, &TurnCredentialProvider::AddressResolve);
+		resolver_->Start(host_);
+
+		return true;
+	}
+	else if (auth_token_.empty())
+	{
+		state_ = AUTHENTICATING;
+		return auth_provider_->Authenticate();
+	}
+	else
+	{
+		// connect the socket 
+		int err = socket_->Connect(host_);
+		return err != SOCKET_ERROR;
+	}
+}
+
+const TurnCredentialProvider::State& TurnCredentialProvider::state() const
+{
+	return state_;
+}
+
+
+void TurnCredentialProvider::SocketOpen(rtc::AsyncSocket* socket)
+{
+	if (state_ != State::NOT_ACTIVE)
+	{
+		return;
+	}
+
+	// format the request
+	std::string data = "GET " + fragment_ + " HTTP/1.1\r\n"
+		"Host: " + host_.hostname() + "\r\n"
+		"Authorization: Bearer " + auth_token_ + "\r\n"
+		"\r\n";
+
+	// send it 
+	auto sent = socket_->Send(data.c_str(), data.length());
+	RTC_DCHECK(sent == data.length());
+
+	state_ = State::ACTIVE;
+}
+
+void TurnCredentialProvider::SocketRead(rtc::AsyncSocket* socket)
+{
+	if (state_ == State::ACTIVE)
+	{
+		TurnCredentials completionData;
+		completionData.successFlag = false;
+
+		// parse response 
+		std::string data;
+		char buffer[0xffff];
+		do
+		{
+			int bytes = socket_->Recv(buffer, sizeof(buffer), nullptr);
+			if (bytes <= 0)
+			{
+				break;
+			}
+
+			data.append(buffer, bytes);
+		} while (true);
+		
+		size_t bodyStart = data.find("\r\n\r\n");
+
+		// if we didn't have a body, something is up.
+		// we want to ignore that data
+		if (data.empty() ||
+			bodyStart == std::string::npos)
+		{
+			return;
+		}
+
+		Json::Reader reader;
+		Json::Value root = NULL;
+
+		// read the response 
+		if (reader.parse(data.substr(bodyStart), root, true))
+		{
+			auto usernameWrapper = root.get("username", NULL);
+			auto passwordWrapper = root.get("password", NULL);
+			if (usernameWrapper != NULL && passwordWrapper != NULL)
+			{
+				auto username = usernameWrapper.asString();
+				auto password = passwordWrapper.asString();
+
+				// if we have values, success
+				if (!username.empty() && !password.empty())
+				{
+					completionData.successFlag = true;
+					completionData.username = username;
+					completionData.password = password;
+				}
+			}
+		}
+
+		// emit the event
+		SignalCredentialsRetrieved.emit(completionData);
+
+		// after emission, we can close our socket 
+		// note: we don't really mind if this fails, it doesn't matter until 
+		// we try another request, at which point we'll handle the error on that call 
+		socket_->Close();
+
+		// after emission, we're totally done, and move to a NOT_ACTIVE state to allow 
+		// more authentication requests to be triggered 
+		state_ = State::NOT_ACTIVE;
+	}
+}
+
+void TurnCredentialProvider::SocketClose(rtc::AsyncSocket* socket, int err)
+{
+	state_ = State::NOT_ACTIVE;
+}
+
+void TurnCredentialProvider::AddressResolve(rtc::AsyncResolverInterface* resolver)
+{
+	// capture the result
+	auto tempHost = resolver->address();
+
+	// release the resolver pointer and destroy the resolver
+	auto released = resolver_.release();
+	released->Destroy(true);
+
+	// reset the resolver pointer to nullptr
+	resolver_.reset(nullptr);
+
+	if (state_ != State::RESOLVING)
+	{
+		return;
+	}
+
+	host_ = tempHost;
+
+	if (auth_token_.empty())
+	{
+		state_ = AUTHENTICATING;
+		if (!auth_provider_->Authenticate())
+		{
+			return;
+		}
+	}
+	else
+	{
+		state_ = State::NOT_ACTIVE;
+	
+		// connect the socket 
+		int err = socket_->Connect(host_);
+	}
+}
+
+void TurnCredentialProvider::OnAuthenticationComplete(const AuthenticationProviderResult& result)
+{
+	if (state_ != State::AUTHENTICATING)
+	{
+		return;
+	}
+
+	if (!result.successFlag)
+	{
+		return;
+	}
+
+	auth_token_ = result.accessToken;
+
+	state_ = State::NOT_ACTIVE;
+
+	// connect the socket 
+	int err = socket_->Connect(host_);
+}

--- a/Samples/Client/DirectxWin32/StreamingDirectxClient.vcxproj
+++ b/Samples/Client/DirectxWin32/StreamingDirectxClient.vcxproj
@@ -202,6 +202,7 @@
     <ClCompile Include="src\defaults.cpp" />
     <ClCompile Include="src\default_main_window.cpp" />
     <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\oauth24d_provider.cpp" />
     <ClCompile Include="src\win32_data_channel_handler.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -214,6 +215,7 @@
     <ClInclude Include="inc\flagdefs.h" />
     <ClInclude Include="inc\macros.h" />
     <ClInclude Include="inc\main_window.h" />
+    <ClInclude Include="inc\oauth24d_provider.h" />
     <ClInclude Include="inc\win32_data_channel_handler.h" />
     <ClInclude Include="inc\webrtc.h" />
     <ClInclude Include="pch.h" />

--- a/Samples/Client/DirectxWin32/StreamingDirectxClient.vcxproj.filters
+++ b/Samples/Client/DirectxWin32/StreamingDirectxClient.vcxproj.filters
@@ -28,6 +28,9 @@
     <ClCompile Include="src\win32_data_channel_handler.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="src\oauth24d_provider.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -62,6 +65,9 @@
       <Filter>Headers</Filter>
     </ClInclude>
     <ClInclude Include="inc\win32_data_channel_handler.h">
+      <Filter>Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\oauth24d_provider.h">
       <Filter>Headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Samples/Client/DirectxWin32/inc/conductor.h
+++ b/Samples/Client/DirectxWin32/inc/conductor.h
@@ -51,6 +51,8 @@ public:
 
 	bool connection_active() const;
 
+	void SetTurnCredentials(const std::string& username, const std::string& password);
+
 	virtual void Close();
 
 protected:
@@ -153,6 +155,8 @@ protected:
 		active_streams_;
 
 	std::string server_;
+	std::string turn_username_;
+	std::string turn_password_;
 };
 
 #endif // WEBRTC_CONDUCTOR_H_

--- a/Samples/Client/DirectxWin32/inc/default_main_window.h
+++ b/Samples/Client/DirectxWin32/inc/default_main_window.h
@@ -83,6 +83,12 @@ public:
 		return wnd_;
 	}
 
+	void SetAuthCode(const std::wstring& str);
+
+	void SetAuthUri(const std::wstring& str);
+
+	void SetConnectButtonState(bool enabled);
+
 	class VideoRenderer : public rtc::VideoSinkInterface<webrtc::VideoFrame>
 	{
 	public:
@@ -158,6 +164,7 @@ protected:
 		LABEL1_ID,
 		LABEL2_ID,
 		LISTBOX_ID,
+		AUTH_ID
 	};
 
 	void OnPaint();
@@ -195,6 +202,10 @@ private:
 	HWND label2_;
 	HWND button_;
 	HWND listbox_;
+	HWND auth_uri_;
+	HWND auth_uri_label_;
+	HWND auth_code_;
+	HWND auth_code_label_;
 	ID2D1Factory* direct2d_factory_;
 	ID2D1HwndRenderTarget* render_target_;
 	bool destroyed_;
@@ -203,8 +214,11 @@ private:
 	static ATOM wnd_class_;
 	std::string server_;
 	std::string port_;
+	std::wstring auth_code_val_;
+	std::wstring auth_uri_val_;
 	bool auto_connect_;
 	bool auto_call_;
+	bool connect_button_state_;
 
 	Win32DataChannelHandler* data_channel_handler_;
 

--- a/Samples/Client/DirectxWin32/inc/flagdefs.h
+++ b/Samples/Client/DirectxWin32/inc/flagdefs.h
@@ -24,6 +24,9 @@ DEFINE_bool(help, false, "Prints this message");
 DEFINE_bool(autoconnect, false, "Connect to the server without user "
                                 "intervention.");
 DEFINE_string(server, "signalingserveruri", "The server to connect to.");
+DEFINE_string(authCodeUri, "authcodeuri", "The server uri that auth code initiation should connect to.");
+DEFINE_string(authPollUri, "authpolluri", "The server uri that auth code polling should connect to.");
+DEFINE_string(turnUri, "turncredentialserveruri", "The turn credential provider uri that we connect to for creds.");
 DEFINE_int(port, kDefaultServerPort,
            "The port on which the server is listening.");
 DEFINE_bool(autocall, false, "Call the first available other client on "

--- a/Samples/Client/DirectxWin32/inc/oauth24d_provider.h
+++ b/Samples/Client/DirectxWin32/inc/oauth24d_provider.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <string>
+
+#include "webrtc/base/sigslot.h"
+#include "webrtc/base/logging.h"
+#include "webrtc/base/physicalsocketserver.h"
+#include "third_party/jsoncpp/source/include/json/json.h"
+
+#include "ssl_capable_socket.h"
+#include "authentication_provider.h"
+
+class OAuth24DProvider : public sigslot::has_slots<>,
+	public MessageHandler,
+	public AuthenticationProvider
+{
+public:
+
+	enum State
+	{
+		NOT_ACTIVE = 0,
+		RESOLVING_CODE,
+		RESOLVING_POLL,
+		REQUEST_CODE,
+		REQUEST_POLL,
+		ACTIVE_CODE,
+		ACTIVE_POLL
+	};
+
+	struct CodeData
+	{
+		std::string device_code;
+		std::string user_code;
+		int interval;
+		std::string verification_url;
+	};
+
+	OAuth24DProvider(const std::string& codeUri, const std::string& pollUri);
+
+	~OAuth24DProvider();
+
+	const State& state() const;
+
+	// emitted when we have the code response and are awaiting user interaction
+	sigslot::signal1<const CodeData&> SignalCodeComplete;
+
+	struct CodeCompleteCallback : public sigslot::has_slots<>
+	{
+		CodeCompleteCallback(const std::function<void(const CodeData&)>& handler) : handler_(handler)
+		{
+		}
+
+		void Handle(const CodeData& data)
+		{
+			handler_(data);
+		}
+	private:
+		std::function<void(const CodeData&)> handler_;
+	};
+
+	// implement AuthenticationProvider
+	virtual bool Authenticate() override;
+
+	// implement MessageHandler
+	virtual void OnMessage(rtc::Message* msg) override;
+
+protected:
+	const int kPollMessageId = 1349U;
+
+	void SocketOpen(rtc::AsyncSocket* socket);
+	void SocketRead(rtc::AsyncSocket* socket);
+	void SocketClose(rtc::AsyncSocket* socket, int err);
+	void AddressResolve(rtc::AsyncResolverInterface* resolver);
+
+	std::string code_uri_;
+	std::string poll_uri_;
+	rtc::SocketAddress code_host_;
+	rtc::SocketAddress poll_host_;
+	State state_;
+	CodeData data_;
+	rtc::Thread* signaling_thread_;
+	std::unique_ptr<SslCapableSocket> socket_;
+	std::unique_ptr<AsyncResolver> resolver_;
+
+private:
+	rtc::SocketAddress SocketAddressFromString(const std::string& str);
+	int ConnectSocket(rtc::SocketAddress addr);
+};

--- a/Samples/Client/DirectxWin32/src/conductor.cpp
+++ b/Samples/Client/DirectxWin32/src/conductor.cpp
@@ -86,6 +86,12 @@ bool Conductor::connection_active() const
 	return peer_connection_.get() != NULL;
 }
 
+void Conductor::SetTurnCredentials(const std::string& username, const std::string& password)
+{
+	turn_username_ = username;
+	turn_password_ = password;
+}
+
 void Conductor::Close() 
 {
 	client_->SignOut();
@@ -177,6 +183,13 @@ bool Conductor::CreatePeerConnection(bool dtls)
 						turnServer.username = jsonTurnServer["username"].asString();
 						turnServer.password = jsonTurnServer["password"].asString();
 					}
+				}
+
+				// if we're given explicit turn creds at runtime, steamroll any config values
+				if (!turn_username_.empty() && !turn_password_.empty())
+				{
+					turnServer.username = turn_username_;
+					turnServer.password = turn_password_;
 				}
 
 				turnServer.tls_cert_policy = webrtc::PeerConnectionInterface::kTlsCertPolicyInsecureNoCheck;

--- a/Samples/Client/DirectxWin32/src/main.cpp
+++ b/Samples/Client/DirectxWin32/src/main.cpp
@@ -3,9 +3,14 @@
 #include <stdlib.h>
 #include <shellapi.h>
 #include <fstream>
+#include <functional>
+#include <algorithm>
 
 #include "webrtc.h"
 #include "third_party/jsoncpp/source/include/json/json.h"
+
+#include "oauth24d_provider.h"
+#include "turn_credential_provider.h"
 
 //--------------------------------------------------------------------------------------
 // Required app libs
@@ -36,7 +41,7 @@ std::string GetAbsolutePath(std::string fileName)
 //--------------------------------------------------------------------------------------
 // WebRTC
 //--------------------------------------------------------------------------------------
-int InitWebRTC(char* server, int port, int heartbeat)
+int InitWebRTC(char* server, int port, int heartbeat, char* authCodeUri, char* authPollUri, char* turnUri)
 {
 	rtc::EnsureWinsockInit();
 	rtc::Win32Thread w32_thread;
@@ -51,12 +56,125 @@ int InitWebRTC(char* server, int port, int heartbeat)
 	}
 
 	rtc::InitializeSSL();
+
+	std::unique_ptr<OAuth24DProvider> oauth;
+	if (strcmp(authCodeUri, FLAG_authCodeUri) != 0 && strcmp(authPollUri, FLAG_authPollUri) != 0)
+	{
+		oauth.reset(new OAuth24DProvider(authCodeUri, authPollUri));
+	}
+
+	// depends on oauth
+	std::unique_ptr<TurnCredentialProvider> turn;
+	if (oauth.get() != nullptr && strcmp(turnUri, FLAG_turnUri) != 0)
+	{
+		turn.reset(new TurnCredentialProvider(turnUri));
+	}
+
 	PeerConnectionClient client;
-
-	client.SetHeartbeatMs(heartbeat);
-
 	rtc::scoped_refptr<Conductor> conductor(
 		new rtc::RefCountedObject<Conductor>(&client, &wnd));
+
+	// set our client heartbeat interval
+	client.SetHeartbeatMs(heartbeat);
+
+	// create (but not necessarily use) async callbacks
+	TurnCredentialProvider::CredentialsRetrievedCallback credentialsRetrieved([&](const TurnCredentials& data)
+	{
+		if (data.successFlag)
+		{
+			conductor->SetTurnCredentials(data.username, data.password);
+
+			wnd.SetConnectButtonState(true);
+
+			// redraw the ui that shows the connect button only if we're currently in that ui
+			if (wnd.current_ui() == DefaultMainWindow::UI::CONNECT_TO_SERVER)
+			{
+				wnd.SwitchToConnectUI();
+			}
+		}
+	});
+	OAuth24DProvider::CodeCompleteCallback codeComplete([&](const OAuth24DProvider::CodeData& data) {
+		std::wstring wcode(data.user_code.begin(), data.user_code.end());
+		std::wstring wuri(data.verification_url.begin(), data.verification_url.end());
+		std::replace(wuri.begin(), wuri.end(), L'\\', L'/');
+
+		// set the ui values
+		wnd.SetAuthCode(wcode);
+		wnd.SetAuthUri(wuri);
+
+		// redraw the ui that shows the code only if we're currently in that ui
+		if (wnd.current_ui() == DefaultMainWindow::UI::CONNECT_TO_SERVER)
+		{
+			wnd.SwitchToConnectUI();
+		}
+	});
+	AuthenticationProvider::AuthenticationCompleteCallback authComplete([&](const AuthenticationProviderResult& data) {
+		if (data.successFlag)
+		{
+			client.SetAuthorizationHeader("Bearer " + data.accessToken);
+
+			// let the user know auth is complete
+			wnd.SetAuthCode(L"OK");
+			wnd.SetAuthUri(L"Authenticated");
+
+			// redraw the ui that shows the code only if we're currently in that ui
+			if (wnd.current_ui() == DefaultMainWindow::UI::CONNECT_TO_SERVER)
+			{
+				wnd.SwitchToConnectUI();
+			}
+		}
+	});
+
+	// if we have real turn values, configure turn
+	if (turn.get() != nullptr)
+	{
+		// disable the connect button until turn is resolved
+		wnd.SetConnectButtonState(false);
+
+		// redraw the ui that shows the code only if we're currently in that ui
+		if (wnd.current_ui() == DefaultMainWindow::UI::CONNECT_TO_SERVER)
+		{
+			wnd.SwitchToConnectUI();
+		}
+
+		turn->SetAuthenticationProvider(oauth.get());
+
+		turn->SignalCredentialsRetrieved.connect(&credentialsRetrieved, &TurnCredentialProvider::CredentialsRetrievedCallback::Handle);
+	}
+
+	// if we have real auth values, indicate that we'll try and connect
+	if (oauth.get() != nullptr)
+	{
+		
+		oauth->SignalCodeComplete.connect(&codeComplete, &OAuth24DProvider::CodeCompleteCallback::Handle);
+		oauth->SignalAuthenticationComplete.connect(&authComplete, &AuthenticationProvider::AuthenticationCompleteCallback::Handle);
+
+		wnd.SetAuthCode(L"Connecting");
+		wnd.SetAuthUri(L"Connecting");
+		
+		// redraw the ui that shows the code only if we're currently in that ui
+		if (wnd.current_ui() == DefaultMainWindow::UI::CONNECT_TO_SERVER)
+		{
+			wnd.SwitchToConnectUI();
+		}
+
+		// do auth things
+		if (turn.get() != nullptr)
+		{
+			// this will trigger oauth->Authenticate() under the hood
+			if (!turn->RequestCredentials())
+			{
+				wnd.SetAuthCode(L"FAIL");
+				wnd.SetAuthUri(L"Unable to request turn creds");
+			}
+		}
+		// if we don't have a turn provider, we just authenticate
+		else if (!oauth->Authenticate())
+		{
+			wnd.SetAuthCode(L"FAIL");
+			wnd.SetAuthUri(L"Unable to authenticate");
+		}
+	}
 
 	// Main loop.
 	MSG msg;
@@ -91,6 +209,12 @@ int WINAPI wWinMain(
 	int nArgs;
 	char server[1024];
 	strcpy(server, FLAG_server);
+	char authCodeUri[1024];
+	strcpy(authCodeUri, FLAG_authCodeUri);
+	char authPollUri[1024];
+	strcpy(authPollUri, FLAG_authPollUri);
+	char turnUri[1024];
+	strcpy(turnUri, FLAG_turnUri);
 	int port = FLAG_port;
 	int heartbeat = FLAG_heartbeat;
 	LPWSTR* szArglist = CommandLineToArgvW(lpCmdLine, &nArgs);
@@ -124,8 +248,37 @@ int WINAPI wWinMain(
 			{
 				heartbeat = root.get("heartbeat", FLAG_heartbeat).asInt();
 			}
+
+			if (root.isMember("turnServer"))
+			{
+				auto turnWrapper = root.get("turnServer", NULL);
+				if (turnWrapper != NULL)
+				{
+					if (turnWrapper.isMember("provider"))
+					{
+						strcpy(turnUri, turnWrapper.get("provider", FLAG_turnUri).asCString());
+					}
+				}
+			}
+
+			if (root.isMember("authentication"))
+			{
+				auto authenticationWrapper = root.get("authentication", NULL);
+				if (authenticationWrapper != NULL)
+				{
+					if (authenticationWrapper.isMember("codeUri"))
+					{
+						strcpy(authCodeUri, authenticationWrapper.get("codeUri", FLAG_authCodeUri).asCString());
+					}
+
+					if (authenticationWrapper.isMember("pollUri"))
+					{
+						strcpy(authPollUri, authenticationWrapper.get("pollUri", FLAG_authPollUri).asCString());
+					}
+				}
+			}
 		}
 	}
 
-	return InitWebRTC(server, port, heartbeat);
+	return InitWebRTC(server, port, heartbeat, authCodeUri, authPollUri, turnUri);
 }

--- a/Samples/Client/DirectxWin32/src/main.cpp
+++ b/Samples/Client/DirectxWin32/src/main.cpp
@@ -58,14 +58,19 @@ int InitWebRTC(char* server, int port, int heartbeat, char* authCodeUri, char* a
 	rtc::InitializeSSL();
 
 	std::unique_ptr<OAuth24DProvider> oauth;
-	if (strcmp(authCodeUri, FLAG_authCodeUri) != 0 && strcmp(authPollUri, FLAG_authPollUri) != 0)
+	if (strcmp(authCodeUri, FLAG_authCodeUri) != 0 &&
+		strcmp(authPollUri, FLAG_authPollUri) != 0 &&
+		!std::string(authCodeUri).empty() &&
+		!std::string(authPollUri).empty())
 	{
 		oauth.reset(new OAuth24DProvider(authCodeUri, authPollUri));
 	}
 
 	// depends on oauth
 	std::unique_ptr<TurnCredentialProvider> turn;
-	if (oauth.get() != nullptr && strcmp(turnUri, FLAG_turnUri) != 0)
+	if (oauth.get() != nullptr &&
+		strcmp(turnUri, FLAG_turnUri) != 0 &&
+		!std::string(turnUri).empty())
 	{
 		turn.reset(new TurnCredentialProvider(turnUri));
 	}

--- a/Samples/Client/DirectxWin32/src/oauth24d_provider.cpp
+++ b/Samples/Client/DirectxWin32/src/oauth24d_provider.cpp
@@ -46,7 +46,13 @@ rtc::SocketAddress OAuth24DProvider::SocketAddressFromString(const std::string& 
 	auto tempHost = str.substr(str.find_first_of("://") + 3);
 	tempHost = tempHost.substr(0, tempHost.find_first_of("/"));
 
-	auto tempPort = tempHost.substr(tempHost.find_first_of(":") + 1);
+	std::string tempPort;
+	
+	if (tempHost.find_first_of(":") != std::string::npos)
+	{
+		tempPort = tempHost.substr(tempHost.find_first_of(":") + 1);
+	}
+
 	tempHost = tempHost.substr(0, tempHost.find_first_of(":"));
 
 	auto addrPort = tempPort.empty() ? (std::string("https://").compare(str.substr(0, 8)) == 0 ? 443 : 80) : atoi(tempPort.c_str());

--- a/Samples/Client/DirectxWin32/src/oauth24d_provider.cpp
+++ b/Samples/Client/DirectxWin32/src/oauth24d_provider.cpp
@@ -1,0 +1,296 @@
+#include "pch.h"
+#include "oauth24d_provider.h"
+
+OAuth24DProvider::OAuth24DProvider(const std::string& codeUri, const std::string& pollUri) :
+	code_uri_(codeUri), poll_uri_(pollUri), state_(State::NOT_ACTIVE)
+{
+	// don't support empty values for these fields
+	if (codeUri.empty() || pollUri.empty())
+	{
+		LOG(LS_ERROR) << __FUNCTION__ << ": invalid parameters, empty";
+		throw std::exception("invalid parameters, empty");
+	}
+
+	code_host_ = SocketAddressFromString(codeUri);
+	poll_host_ = SocketAddressFromString(pollUri);
+
+	// configure the thread which will be used for socket signalling. it's just some representation of
+	// the current thread (wrapped or existing)
+	auto socketThread = rtc::Thread::Current();
+	socketThread = socketThread == nullptr ? rtc::ThreadManager::Instance()->WrapCurrentThread() : socketThread;
+
+	signaling_thread_ = socketThread;
+}
+
+OAuth24DProvider::~OAuth24DProvider()
+{
+	if (resolver_.get() != nullptr)
+	{
+		// release the resolver pointer and destroy the resolver
+		auto released = resolver_.release();
+		released->Destroy(true);
+
+		// reset the resolver pointer to nullptr
+		resolver_.reset(nullptr);
+	}
+}
+
+const OAuth24DProvider::State& OAuth24DProvider::state() const
+{
+	return state_;
+}
+
+rtc::SocketAddress OAuth24DProvider::SocketAddressFromString(const std::string& str)
+{
+	// take the hostname, <protocol>://<hostname>[:port]/ 
+	auto tempHost = str.substr(str.find_first_of("://") + 3);
+	tempHost = tempHost.substr(0, tempHost.find_first_of("/"));
+
+	auto tempPort = tempHost.substr(tempHost.find_first_of(":") + 1);
+	tempHost = tempHost.substr(0, tempHost.find_first_of(":"));
+
+	auto addrPort = tempPort.empty() ? (std::string("https://").compare(str.substr(0, 8)) == 0 ? 443 : 80) : atoi(tempPort.c_str());
+	return rtc::SocketAddress(tempHost, addrPort);
+}
+
+int OAuth24DProvider::ConnectSocket(rtc::SocketAddress addr)
+{
+	socket_.reset(new SslCapableSocket(addr.family(), addr.port() == 443, signaling_thread_));
+	socket_->SignalCloseEvent.connect(this, &OAuth24DProvider::SocketClose);
+	socket_->SignalConnectEvent.connect(this, &OAuth24DProvider::SocketOpen);
+	socket_->SignalReadEvent.connect(this, &OAuth24DProvider::SocketRead);
+
+	return socket_->Connect(addr);
+}
+
+bool OAuth24DProvider::Authenticate()
+{
+	if (state_ != State::NOT_ACTIVE)
+	{
+		return false;
+	}
+
+	if (code_host_.IsUnresolvedIP())
+	{
+		state_ = RESOLVING_CODE;
+		resolver_.reset(new rtc::AsyncResolver());
+		resolver_->SignalDone.connect(this, &OAuth24DProvider::AddressResolve);
+		resolver_->Start(code_host_);
+
+		return true;
+	}
+
+	if (poll_host_.IsUnresolvedIP())
+	{
+		state_ = RESOLVING_POLL;
+		resolver_.reset(new rtc::AsyncResolver());
+		resolver_->SignalDone.connect(this, &OAuth24DProvider::AddressResolve);
+		resolver_->Start(poll_host_);
+
+		return true;
+	}
+
+	state_ = State::REQUEST_CODE;
+
+	int err = ConnectSocket(code_host_);
+
+	return err != SOCKET_ERROR;
+}
+
+void OAuth24DProvider::OnMessage(rtc::Message* msg)
+{
+	// this indicates it's time to poll again
+	if (msg->message_id == kPollMessageId)
+	{
+		ConnectSocket(poll_host_);
+	}
+}
+
+void OAuth24DProvider::SocketOpen(rtc::AsyncSocket* socket)
+{
+	// issue the code query
+	if (state_ == State::REQUEST_CODE)
+	{
+		auto data = "GET " + code_uri_ + " HTTP/1.1\r\n"
+			"Host: " + code_host_.hostname() + "\r\n\r\n";
+
+		auto sent = socket_->Send(data.c_str(), data.length());
+		RTC_DCHECK(sent == data.length());
+		
+		state_ = State::ACTIVE_CODE;
+	}
+	// issue the poll query
+	else if (state_ == State::REQUEST_POLL)
+	{
+		auto data = "GET " + poll_uri_ + "?device_code=" + data_.device_code + " HTTP/1.1\r\n"
+			"Host: " + poll_host_.hostname() + "\r\n\r\n";
+
+		auto sent = socket_->Send(data.c_str(), data.length());
+		RTC_DCHECK(sent == data.length());
+
+		state_ = State::ACTIVE_POLL;
+	}
+}
+
+void OAuth24DProvider::SocketRead(rtc::AsyncSocket* socket)
+{
+	std::string data;
+
+	if (state_ == State::ACTIVE_CODE || state_ == State::ACTIVE_POLL)
+	{
+		// parse response
+		char buffer[0xffff];
+		do
+		{
+			int bytes = socket_->Recv(buffer, sizeof(buffer), nullptr);
+			if (bytes <= 0)
+			{
+				break;
+			}
+
+			data.append(buffer, bytes);
+		} while (true);
+	}
+
+	size_t bodyStart = data.find("\r\n\r\n");
+
+	// if we didn't have a body, something is up.
+	// we want to ignore that data
+	if (data.empty() ||
+		bodyStart == std::string::npos)
+	{
+		return;
+	}
+
+	Json::Reader reader;
+	Json::Value root = NULL;
+
+	// read the response 
+	if (reader.parse(data.substr(bodyStart), root, true))
+	{
+		if (state_ == State::ACTIVE_CODE)
+		{
+			auto deviceCodeWrapper = root.get("device_code", NULL);
+			if (deviceCodeWrapper != NULL)
+			{
+				data_.device_code = deviceCodeWrapper.asString();
+			}
+
+			auto userCodeWrapper = root.get("user_code", NULL);
+			if (userCodeWrapper != NULL)
+			{
+				data_.user_code = userCodeWrapper.asString();
+			}
+
+			auto intervalWrapper = root.get("interval", NULL);
+			if (intervalWrapper != NULL)
+			{
+				data_.interval = intervalWrapper.asInt();
+			}
+
+			auto verificationUrlWrapper = root.get("verification_url", NULL);
+			if (verificationUrlWrapper != NULL)
+			{
+				data_.verification_url = verificationUrlWrapper.asString();
+			}
+
+			// emit the code complete event
+			SignalCodeComplete.emit(data_);
+
+			// start polling
+			state_ = State::REQUEST_POLL;
+
+			socket_->Close();
+			ConnectSocket(poll_host_);
+		}
+		else if (state_ == State::ACTIVE_POLL)
+		{
+			// get response status
+			int status = -1;
+			size_t pos = data.find(' ');
+			if (pos != std::string::npos)
+			{
+				status = atoi(&data[pos + 1]);
+			}
+
+			if (status == 400)
+			{
+				// poll again
+				state_ = State::REQUEST_POLL;
+
+				socket_->Close();
+
+				// schedule another poll at the interval from the CODE message
+				signaling_thread_->PostDelayed(RTC_FROM_HERE, data_.interval * 1000, this, kPollMessageId);
+			}
+			else if (status == 200)
+			{
+				AuthenticationProviderResult completionData;
+				completionData.successFlag = true;
+
+				auto accessCodeWrapper = root.get("access_code", NULL);
+				if (accessCodeWrapper != NULL)
+				{
+					completionData.accessToken = accessCodeWrapper.asString();
+				}
+
+				// emit the event
+				SignalAuthenticationComplete.emit(completionData);
+
+				// after emission, we can close our socket 
+				// note: we don't really mind if this fails, it doesn't matter until 
+				// we try another request, at which point we'll handle the error on that call 
+				socket_->Close();
+
+				// after emission, we're totally done, and move to a NOT_ACTIVE state to allow 
+				// more authentication requests to be triggered 
+				state_ = State::NOT_ACTIVE;
+			}
+		}
+	}
+}
+
+void OAuth24DProvider::SocketClose(rtc::AsyncSocket* socket, int err)
+{
+	// TODO(bengreenier): remove this handler
+	return;
+}
+
+void OAuth24DProvider::AddressResolve(rtc::AsyncResolverInterface* resolver)
+{
+	// capture the result
+	auto tempHost = resolver->address();
+
+	// release the resolver pointer and destroy the resolver
+	auto released = resolver_.release();
+	released->Destroy(true);
+
+	// reset the resolver pointer to nullptr
+	resolver_.reset(nullptr);
+
+	if (state_ != State::RESOLVING_CODE && state_ != State::RESOLVING_POLL)
+	{
+		return;
+	}
+
+	if (state_ == State::RESOLVING_CODE)
+	{
+		code_host_ = tempHost;
+
+		if (poll_host_.IsUnresolvedIP())
+		{
+			state_ = RESOLVING_POLL;
+			resolver_.reset(new rtc::AsyncResolver());
+			resolver_->SignalDone.connect(this, &OAuth24DProvider::AddressResolve);
+			resolver_->Start(poll_host_);
+			
+			return;
+		}
+	}
+
+	poll_host_ = tempHost;
+	state_ = State::REQUEST_CODE;
+	
+	// connect the socket to code_host_ to REQUEST_CODE
+	ConnectSocket(code_host_);
+}

--- a/Samples/Client/DirectxWin32/webrtcConfig.json
+++ b/Samples/Client/DirectxWin32/webrtcConfig.json
@@ -3,9 +3,14 @@
   "turnServer": {
     "uri": "turn:turnserveruri:5349",
     "username": "username",
-    "password": "password"
+    "password": "password",
+    "provider":  ""
   },
   "server": "https://signalingserveruri",
   "port": 443,
-  "heartbeat": 5000
+  "heartbeat": 5000,
+  "authentication": {
+    "codeUri": "",
+    "pollUri": ""
+  }
 }


### PR DESCRIPTION
This provides authentication support for native client auth. tested against `SpinningCubeServer` and our temp turn creds enabled identity service (with oauth24d support) and turn server

# Related docs changes
- [ ] document new config values
- [ ] document how to use oauth24d
- [ ] document how to setup an oauth24d server (and link to our version)

# Changes

> TLDR: native client can now use user auth (oauth24d flow) and temporary turn creds

+ Steal `TurnCredentialProvider` from `feature/authentication` (note: this means we'll need to merge properly when we do `feature/authentication`)
+ Steal `AuthenticationProvider` from `feature/authentication` (same note)
+ Add `OAuth24DProvider` implementing [oauth24d flow](https://developers.google.com/identity/protocols/OAuth2ForDevices) for native client auth
+ Modify the `DefaultMainWindow` ui to support async authentication, and presentation of auth values
+ Add new config values and parsing code for `webrtcConfig.json`