### PR TITLE
modified config to copy webrtcConfig.json if newer

### DIFF
--- a/Samples/Client/DirectxUWP/DirectxClient/StreamingDirectxHololensClient.csproj
+++ b/Samples/Client/DirectxUWP/DirectxClient/StreamingDirectxHololensClient.csproj
@@ -69,7 +69,9 @@
     <None Include="project.json" />
     <Content Include="VPRTVertexShader.cso" />
     <Content Include="VertexShader.cso" />
-    <Content Include="webrtcConfig.json" />
+    <Content Include="webrtcConfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.cs" />


### PR DESCRIPTION
Saw that webrtcConfig.json wasn't in the build of StreamingDirectXHoloLensClient in File Explorer. I modified the config to copy webrtcConfig.json "if newer". 