### PR TITLE
buildeng: replace xcopy with robocopy

### DIFF
--- a/Plugins/UnityClientPlugin/MediaEngineUWP/UWP/MediaEngineUWP.vcxproj
+++ b/Plugins/UnityClientPlugin/MediaEngineUWP/UWP/MediaEngineUWP.vcxproj
@@ -119,25 +119,6 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>MediaPlayback.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>SETLOCAL
-      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\..\..\Samples\Client\Unity\Assets\
-
-      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
-
-      mkdir "%TARGET_PLUGIN_PATH%Plugins"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\WSA"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)"
-
-      copy /Y "$(TargetPath)" "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)\MediaEngineUWP$(TargetExt)"
-      copy /Y "$(TargetPath)" "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)\MediaEngineUWP.pdb"
-ENDLOCAL
-      </Command>
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -152,25 +133,6 @@ ENDLOCAL
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>MediaPlayback.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>SETLOCAL
-      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\..\..\Samples\Client\Unity\Assets\
-
-      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
-
-      mkdir "%TARGET_PLUGIN_PATH%Plugins"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\WSA"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)"
-
-      copy /Y "$(TargetPath)" "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)\MediaEngineUWP$(TargetExt)"
-      copy /Y "$(TargetPath)" "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)\MediaEngineUWP.pdb"
-ENDLOCAL
-      </Command>
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -187,14 +149,6 @@ ENDLOCAL
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      </Command>
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -211,16 +165,18 @@ ENDLOCAL
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      </Command>
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>SETLOCAL
+set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\..\..\Samples\Client\Unity\Assets\
+echo Target Plugin Path is %25TARGET_PLUGIN_PATH%25
+robocopy /NP /R:3 /W:2 "$(OutDir)." "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)." "$(TargetName)$(TargetExt)" "$(TargetName).pdb"
+IF %ERRORLEVEL% GTR 7 (exit 1) ELSE (exit 0)
+ENDLOCAL</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Plugins/UnityClientPlugin/TexturesUWP/TexturesUWP.vcxproj
+++ b/Plugins/UnityClientPlugin/TexturesUWP/TexturesUWP.vcxproj
@@ -93,21 +93,6 @@
       <AdditionalDependencies>libyuv_win10_x86.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/nodefaultlib:vccorlibd /nodefaultlib:msvcrtd vccorlibd.lib msvcrtd.lib</AdditionalOptions>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      SETLOCAL
-      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\..\Samples\Client\Unity\Assets\
-
-      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
-
-      mkdir "%TARGET_PLUGIN_PATH%Plugins"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\WSA"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)"
-
-      copy /Y "$(TargetPath)" "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)\TexturesUWP$(TargetExt)"
-      ENDLOCAL
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -127,21 +112,6 @@
       </AdditionalManifestDependencies>
       <AdditionalOptions>/nodefaultlib:vccorlib /nodefaultlib:msvcrt vccorlib.lib msvcrt.lib</AdditionalOptions>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      SETLOCAL
-      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\..\Samples\Client\Unity\Assets\
-
-      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
-
-      mkdir "%TARGET_PLUGIN_PATH%Plugins"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\WSA"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)"
-
-      copy /Y "$(TargetPath)" "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)\TexturesUWP$(TargetExt)"
-      ENDLOCAL
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -227,4 +197,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>SETLOCAL
+set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\..\Samples\Client\Unity\Assets\
+echo Target Plugin Path is %25TARGET_PLUGIN_PATH%25
+robocopy /NP /R:3 /W:2 "$(OutDir)." "%TARGET_PLUGIN_PATH%Plugins\WSA\$(PlatformShortName)." "$(TargetName)$(TargetExt)" "$(TargetName).pdb"
+IF %ERRORLEVEL% GTR 7 (exit 1) ELSE (exit 0)
+ENDLOCAL</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Plugins/UnityClientPlugin/WebRtcWrapper/WebRtcWrapper.csproj
+++ b/Plugins/UnityClientPlugin/WebRtcWrapper/WebRtcWrapper.csproj
@@ -113,14 +113,10 @@
     <PostBuildEvent>SETLOCAL
 set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\..\Samples\Client\Unity\Assets\
 echo Target Plugin Path is %25TARGET_PLUGIN_PATH%25
-mkdir "%25TARGET_PLUGIN_PATH%25Plugins"
-mkdir "%25TARGET_PLUGIN_PATH%25Plugins\WSA"
-mkdir "%25TARGET_PLUGIN_PATH%25Plugins\WSA\$(Platform)"
-xcopy /R /I /Y "$(OutDir)$(TargetName)$(TargetExt)" "%25TARGET_PLUGIN_PATH%25Plugins\WSA"
-xcopy /R /I /Y "$(OutDir)$(TargetName).pdb" "%25TARGET_PLUGIN_PATH%25Plugins\WSA"
-xcopy /R /I /Y "$(OutDir)Org.WebRtc.dll" "%25TARGET_PLUGIN_PATH%25Plugins\WSA\$(Platform)"
-xcopy /R /I /Y "$(OutDir)Org.WebRtc.winmd" "%25TARGET_PLUGIN_PATH%25Plugins\WSA\$(Platform)"
-
+robocopy /NP /R:3 /W:2 "$(OutDir)." "%25TARGET_PLUGIN_PATH%25Plugins\WSA" "$(TargetName)$(TargetExt)" "$(TargetName).pdb"
+IF %ERRORLEVEL% GTR 7 exit 1
+robocopy /NP /R:3 /W:2 "$(OutDir)." "%25TARGET_PLUGIN_PATH%25Plugins\WSA\$(Platform)" "Org.WebRtc.dll" "Org.WebRtc.winmd"
+IF %ERRORLEVEL% GTR 7 (exit 2) ELSE (exit 0)
 ENDLOCAL</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Plugins/UnityServerPlugin/StreamingUnityServerPlugin.vcxproj
+++ b/Plugins/UnityServerPlugin/StreamingUnityServerPlugin.vcxproj
@@ -113,25 +113,6 @@
       <AdditionalDependencies>ffmpeg.dll.lib;boringssl.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4217,4049</AdditionalOptions>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      SETLOCAL
-      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\Samples\Server\Unity-FractalStream\Assets\
-
-      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
-
-      mkdir "%TARGET_PLUGIN_PATH%Plugins"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-
-      xcopy /y $(OutDir)*.dll "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      xcopy /y $(OutDir)*.pdb "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      xcopy /y $(OutDir)*.json "%TARGET_PLUGIN_PATH%Plugins"
-      xcopy /y /d  "$(ProjectDir)..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer" 
-      xcopy /y /d  "$(ProjectDir)..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      ENDLOCAL
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -149,25 +130,6 @@
       <AdditionalDependencies>ffmpeg.dll.lib;boringssl.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4217,4049</AdditionalOptions>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      SETLOCAL
-      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\Samples\Server\Unity-FractalStream\Assets\
-
-      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
-
-      mkdir "%TARGET_PLUGIN_PATH%Plugins"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-
-      xcopy /y $(OutDir)*.dll "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      xcopy /y $(OutDir)*.pdb "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      xcopy /y $(OutDir)*.json "%TARGET_PLUGIN_PATH%Plugins"
-      xcopy /y /d  "$(ProjectDir)..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer" 
-      xcopy /y /d  "$(ProjectDir)..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      ENDLOCAL
-      </Command>   
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -190,23 +152,6 @@
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4217,4049</AdditionalOptions>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      SETLOCAL
-      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\Samples\Server\Unity-FractalStream\Assets\
-
-      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
-
-      mkdir "%TARGET_PLUGIN_PATH%Plugins"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-
-      xcopy /y $(OutDir)*.dll "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      xcopy /y $(OutDir)*.pdb "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      xcopy /y $(OutDir)*.json "%TARGET_PLUGIN_PATH%Plugins"
-      ENDLOCAL
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -229,23 +174,6 @@
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4217,4049</AdditionalOptions>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      SETLOCAL
-      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\Samples\Server\Unity-FractalStream\Assets\
-
-      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
-
-      mkdir "%TARGET_PLUGIN_PATH%Plugins"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)"
-      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-
-      xcopy /y $(OutDir)*.dll "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      xcopy /y $(OutDir)*.pdb "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
-      xcopy /y $(OutDir)*.json "%TARGET_PLUGIN_PATH%Plugins"
-      ENDLOCAL
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="StreamingUnityServerPlugin.cpp" />
@@ -268,4 +196,24 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      SETLOCAL
+      set TARGET_PLUGIN_PATH=$(ProjectDir)..\..\Samples\Server\Unity-FractalStream\Assets\
+
+      echo Target Plugin Path is %TARGET_PLUGIN_PATH%
+
+      mkdir "%TARGET_PLUGIN_PATH%Plugins"
+      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)"
+      mkdir "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer"
+
+      robocopy /NP /R:3 /W:2 "$(OutDir)\." "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer" *.dll *.pdb *.json
+      IF %ERRORLEVEL% GTR 7 exit 1
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll" "%TARGET_PLUGIN_PATH%Plugins\$(PlatformShortName)\StreamingServer" boringssl.dll ffmpeg.dll
+      IF %ERRORLEVEL% GTR 7 (exit 2) ELSE (exit 0)
+      ENDLOCAL
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Samples/Client/DirectxUWP/DirectxClientComponent/DirectxClientComponent.vcxproj
+++ b/Samples/Client/DirectxUWP/DirectxClientComponent/DirectxClientComponent.vcxproj
@@ -111,9 +111,6 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <AdditionalDependencies>WindowsApp.lib;libyuv_win10_x86.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y /s /d $(OutDir)*.cso $(ProjectDir)..\DirectxClient</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -132,9 +129,6 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <AdditionalDependencies>WindowsApp.lib;libyuv_win10_x86.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y /s /d $(OutDir)*.cso $(ProjectDir)..\DirectxClient</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -153,9 +147,6 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <AdditionalDependencies>WindowsApp.lib;libyuv_win10_x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y /s /d $(OutDir)*.cso $(ProjectDir)..\DirectxClient</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -174,9 +165,6 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <AdditionalDependencies>WindowsApp.lib;libyuv_win10_x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y /s /d $(OutDir)*.cso $(ProjectDir)..\DirectxClient</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\Plugins\UnityClientPlugin\MediaEngineUWP\Shared\d3dmanagerlock.hxx" />
@@ -248,4 +236,12 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      robocopy /NP /R:3 /W:2 "$(OutDir)\." "$(ProjectDir)..\DirectxClient" *.cso
+      IF %ERRORLEVEL% GTR 7 (exit 1) ELSE (exit 0)
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Samples/Client/DirectxWin32/StreamingDirectxClient.vcxproj
+++ b/Samples/Client/DirectxWin32/StreamingDirectxClient.vcxproj
@@ -107,9 +107,6 @@
     <FxCompile>
       <ObjectFileOutput>$(OutDir)%(Filename).cso</ObjectFileOutput>
     </FxCompile>
-    <PostBuildEvent>
-      <Command>xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
     <Manifest>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
@@ -131,9 +128,6 @@
       <AdditionalDependencies>ffmpeg.dll.lib;boringssl.dll.lib;DirectXTK.lib;d2d1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4217,4049</AdditionalOptions>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
     <Manifest>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
@@ -225,4 +219,12 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Libraries\Authentication\exports.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Libraries\UserInterface\exports.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll" "$(OutDir)." boringssl.dll ffmpeg.dll
+      IF %ERRORLEVEL% GTR 7 (exit 1) ELSE (exit 0)
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Samples/Server/Directx-Multithreaded/MultithreadedServer.vcxproj
+++ b/Samples/Server/Directx-Multithreaded/MultithreadedServer.vcxproj
@@ -125,18 +125,6 @@
     <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
-    <PostBuildEvent>
-      <Command>
-      IF NOT EXIST $(OutDir)xcopy.lock (
-      type nul &gt; $(OutDir)xcopy.lock
-        xcopy /y /s /d /r $(ProjectDir)Media $(OutDir)
-        xcopy /y /d /r $(ProjectDir)*.hlsl  $(OutDir)
-        xcopy /y /d /r  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" 
-        xcopy /y /d /r  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"
-      )
-      del /f /q xcopy.lock
-      </Command>
-    </PostBuildEvent>
     <ProjectReference>
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -179,18 +167,6 @@
     <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
-    <PostBuildEvent>
-      <Command>
-      IF NOT EXIST $(OutDir)xcopy.lock (
-      type nul &gt; $(OutDir)xcopy.lock
-        xcopy /y /s /d /r $(ProjectDir)Media $(OutDir)
-        xcopy /y /d /r $(ProjectDir)*.hlsl  $(OutDir)
-        xcopy /y /d /r  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" 
-        xcopy /y /d /r  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"
-      )
-      del /f /q xcopy.lock
-      </Command>
-    </PostBuildEvent>
     <ProjectReference>
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -235,22 +211,6 @@
     <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
-    <PostBuildEvent>
-      <Command>
-      IF NOT EXIST $(OutDir)xcopy.lock (
-      type nul &gt; $(OutDir)xcopy.lock
-        xcopy /y /s /d /r $(ProjectDir)Media $(OutDir)
-        xcopy /y /d /r $(ProjectDir)*.hlsl  $(OutDir)
-        xcopy /y /d /r  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" 
-        xcopy /y /d /r  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"
-      )
-      del /f /q xcopy.lock
-      </Command>
-    </PostBuildEvent>
     <ProjectReference>
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -294,20 +254,6 @@
     <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
-    <PostBuildEvent>
-      <Command>
-      IF NOT EXIST $(OutDir)xcopy.lock (
-      type nul &gt; $(OutDir)xcopy.lock
-        xcopy /y /s /d /r $(ProjectDir)Media $(OutDir)
-        xcopy /y /d /r $(ProjectDir)*.hlsl  $(OutDir)
-      )
-      del /f /q xcopy.lock
-      </Command>
-    </PostBuildEvent>
     <ProjectReference>
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -349,4 +295,20 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Plugins\NativeServerPlugin\exports.props" />
   <ImportGroup Label="ExtensionTargets" />
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      IF NOT EXIST $(OutDir)binarycopy.lock (
+      type nul &gt; $(OutDir)binarycopy.lock
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)Media" "$(OutDir)."
+      IF %ERRORLEVEL% GTR 7 exit 1
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.hlsl
+      IF %ERRORLEVEL% GTR 7 exit 2
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll" "$(OutDir)." boringssl.dll ffmpeg.dll
+      IF %ERRORLEVEL% GTR 7 (exit 3) ELSE (exit 0)
+      )
+      del /f /q binarycopy.lock
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Samples/Server/Directx-Multithreaded/MultithreadedServer.vcxproj
+++ b/Samples/Server/Directx-Multithreaded/MultithreadedServer.vcxproj
@@ -300,14 +300,14 @@
       <Command>
       IF NOT EXIST $(OutDir)binarycopy.lock (
       type nul &gt; $(OutDir)binarycopy.lock
-      robocopy /NP /R:3 /W:2 "$(ProjectDir)Media" "$(OutDir)."
+      robocopy /NP /R:3 /W:2 /S "$(ProjectDir)Media" "$(OutDir)."
       IF %ERRORLEVEL% GTR 7 exit 1
       robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.hlsl
       IF %ERRORLEVEL% GTR 7 exit 2
       robocopy /NP /R:3 /W:2 "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll" "$(OutDir)." boringssl.dll ffmpeg.dll
       IF %ERRORLEVEL% GTR 7 (exit 3) ELSE (exit 0)
       )
-      del /f /q binarycopy.lock
+      del /f /q $(OutDir)binarycopy.lock
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/Samples/Server/Directx-Multithreaded/MultithreadedServerService.vcxproj
+++ b/Samples/Server/Directx-Multithreaded/MultithreadedServerService.vcxproj
@@ -304,14 +304,14 @@
       <Command>
       IF NOT EXIST $(OutDir)binarycopy.lock (
       type nul &gt; $(OutDir)binarycopy.lock
-      robocopy /NP /R:3 /W:2 "$(ProjectDir)Media" "$(OutDir)."
+      robocopy /NP /R:3 /W:2 /S "$(ProjectDir)Media" "$(OutDir)."
       IF %ERRORLEVEL% GTR 7 exit 1
       robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.hlsl
       IF %ERRORLEVEL% GTR 7 exit 2
       robocopy /NP /R:3 /W:2 "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll" "$(OutDir)." boringssl.dll ffmpeg.dll
       IF %ERRORLEVEL% GTR 7 (exit 3) ELSE (exit 0)
       )
-      del /f /q binarycopy.lock
+      del /f /q $(OutDir)binarycopy.lock
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/Samples/Server/Directx-Multithreaded/MultithreadedServerService.vcxproj
+++ b/Samples/Server/Directx-Multithreaded/MultithreadedServerService.vcxproj
@@ -131,13 +131,6 @@
     <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
-    <PostBuildEvent>
-      <Command>xcopy /y /s /d $(ProjectDir)Media $(OutDir) &amp;&amp; xcopy /y /d $(ProjectDir)*.hlsl  $(OutDir) &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
     <ProjectReference />
     <ProjectReference>
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
@@ -180,18 +173,6 @@
     <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
-    <PostBuildEvent>
-      <Command>
-      IF NOT EXIST $(OutDir)xcopy.lock (
-      type nul &gt; $(OutDir)xcopy.lock
-        xcopy /y /s /d /r $(ProjectDir)Media $(OutDir)
-        xcopy /y /d /r $(ProjectDir)*.hlsl  $(OutDir)
-        xcopy /y /d /r  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" 
-        xcopy /y /d /r  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"
-      )
-      del /f /q xcopy.lock
-      </Command>
-    </PostBuildEvent>
     <ProjectReference>
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -235,16 +216,6 @@
     <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
-    <PostBuildEvent>
-      <Command>
-      IF NOT EXIST $(OutDir)xcopy.lock (
-      type nul &gt; $(OutDir)xcopy.lock
-        xcopy /y /s /d /r $(ProjectDir)Media $(OutDir)
-        xcopy /y /d /r $(ProjectDir)*.hlsl  $(OutDir)
-      )
-      del /f /q xcopy.lock
-      </Command>
-    </PostBuildEvent>
     <ProjectReference>
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -287,16 +258,6 @@
     <Manifest>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
-    <PostBuildEvent>
-      <Command>
-      IF NOT EXIST $(OutDir)xcopy.lock (
-      type nul &gt; $(OutDir)xcopy.lock
-        xcopy /y /s /d /r $(ProjectDir)Media $(OutDir)
-        xcopy /y /d /r $(ProjectDir)*.hlsl  $(OutDir)
-      )
-      del /f /q xcopy.lock
-      </Command>
-    </PostBuildEvent>
     <ProjectReference>
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -338,4 +299,20 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Plugins\NativeServerPlugin\exports.props" />
   <ImportGroup Label="ExtensionTargets" />
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      IF NOT EXIST $(OutDir)binarycopy.lock (
+      type nul &gt; $(OutDir)binarycopy.lock
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)Media" "$(OutDir)."
+      IF %ERRORLEVEL% GTR 7 exit 1
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.hlsl
+      IF %ERRORLEVEL% GTR 7 exit 2
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll" "$(OutDir)." boringssl.dll ffmpeg.dll
+      IF %ERRORLEVEL% GTR 7 (exit 3) ELSE (exit 0)
+      )
+      del /f /q binarycopy.lock
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Samples/Server/Directx-Multithreaded/MultithreadedTestRunner.vcxproj
+++ b/Samples/Server/Directx-Multithreaded/MultithreadedTestRunner.vcxproj
@@ -309,12 +309,12 @@
       <Command>
       IF NOT EXIST $(OutDir)binarycopy.lock (
       type nul &gt; $(OutDir)binarycopy.lock
-      robocopy /NP /R:3 /W:2 "$(ProjectDir)Media" "$(OutDir)."
+      robocopy /NP /R:3 /W:2 /S "$(ProjectDir)Media" "$(OutDir)."
       IF %ERRORLEVEL% GTR 7 exit 1
       robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.hlsl
       IF %ERRORLEVEL% GTR 7 (exit 2) ELSE (exit 0)
       )
-      del /f /q binarycopy.lock
+      del /f /q $(OutDir)binarycopy.lock
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/Samples/Server/Directx-Multithreaded/MultithreadedTestRunner.vcxproj
+++ b/Samples/Server/Directx-Multithreaded/MultithreadedTestRunner.vcxproj
@@ -92,18 +92,6 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <LibraryPath>$(LibraryPath)</LibraryPath>
   </PropertyGroup>
-  <ItemDefinitionGroup>
-    <PostBuildEvent>
-      <Command>
-      IF NOT EXIST $(OutDir)xcopy.lock (
-      type nul &gt; $(OutDir)xcopy.lock
-        xcopy /y /s /d /r $(ProjectDir)Media $(OutDir)
-        xcopy /y /d /r $(ProjectDir)*.hlsl  $(OutDir)
-      )
-      del /f /q xcopy.lock
-      </Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
@@ -316,4 +304,18 @@
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Plugins\NativeServerPlugin\exports.props" />
   <ImportGroup Label="ExtensionTargets" />
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      IF NOT EXIST $(OutDir)binarycopy.lock (
+      type nul &gt; $(OutDir)binarycopy.lock
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)Media" "$(OutDir)."
+      IF %ERRORLEVEL% GTR 7 exit 1
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.hlsl
+      IF %ERRORLEVEL% GTR 7 (exit 2) ELSE (exit 0)
+      )
+      del /f /q binarycopy.lock
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Samples/Server/Directx-SpinningCube/SpinningCubeServer.vcxproj
+++ b/Samples/Server/Directx-SpinningCube/SpinningCubeServer.vcxproj
@@ -109,9 +109,6 @@
     <FxCompile>
       <ObjectFileOutput>$(OutDir)%(Filename).cso</ObjectFileOutput>
     </FxCompile>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir) &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -133,9 +130,6 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir) &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -160,9 +154,6 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir)</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -187,9 +178,6 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir)</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FxCompile Include="Shaders\PixelShader.hlsl">
@@ -229,4 +217,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Plugins\NativeServerPlugin\exports.props" />
   <ImportGroup Label="ExtensionTargets" />
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.cso
+      IF %ERRORLEVEL% GTR 7 exit 1
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll" "$(OutDir)." boringssl.dll ffmpeg.dll
+      IF %ERRORLEVEL% GTR 7 (exit 2) ELSE (exit 0)
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Samples/Server/Directx-SpinningCube/SpinningCubeServerService.vcxproj
+++ b/Samples/Server/Directx-SpinningCube/SpinningCubeServerService.vcxproj
@@ -109,9 +109,6 @@
     <FxCompile>
       <ObjectFileOutput>$(OutDir)%(Filename).cso</ObjectFileOutput>
     </FxCompile>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir) &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -133,9 +130,6 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir) &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\boringssl.dll" "$(OutDir)" &amp;&amp; xcopy /y /d  "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll\ffmpeg.dll" "$(OutDir)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -160,9 +154,6 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir)</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -187,9 +178,6 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir)</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FxCompile Include="Shaders\PixelShader.hlsl">
@@ -229,4 +217,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Plugins\NativeServerPlugin\exports.props" />
   <ImportGroup Label="ExtensionTargets" />
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.cso
+      IF %ERRORLEVEL% GTR 7 exit 1
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)..\..\..\Libraries\WebRTC\$(Platform)\$(Configuration)\dll" "$(OutDir)." boringssl.dll ffmpeg.dll
+      IF %ERRORLEVEL% GTR 7 (exit 2) ELSE (exit 0)
+      exit 0
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>

--- a/Samples/Server/Directx-SpinningCube/SpinningCubeTestRunner.vcxproj
+++ b/Samples/Server/Directx-SpinningCube/SpinningCubeTestRunner.vcxproj
@@ -150,9 +150,6 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir)</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -176,9 +173,6 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /y $(OutDir)*.cso $(ProjectDir)</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FxCompile Include="Shaders\PixelShader.hlsl">
@@ -227,4 +221,12 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Plugins\NativeServerPlugin\exports.props" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>
+      robocopy /NP /R:3 /W:2 "$(ProjectDir)." "$(OutDir)." *.cso
+      IF %ERRORLEVEL% GTR 7 (exit 1) ELSE (exit 0)
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
robocopy is capable of working with paths > `MAX_PATH`. This replaces all our `PostBuildEvent` `xcopy` calls with `robocopy`.

Need to verify these things before merging:

+ [ ] - This should fix #70