### PR TITLE
update RTCIceServer config props to latest spec

### DIFF
--- a/Samples/Client/WebClient/config.js
+++ b/Samples/Client/WebClient/config.js
@@ -1,8 +1,8 @@
 var pcConfigStatic = {
     "iceServers": [{
-        "url": "turn:turnserveruri:5349",
+        "urls": "turn:turnserveruri:5349",
         "username": "username",
-        "password": "password",
+        "credential": "password",
         "credentialType": "password"
     }],
     "iceTransportPolicy": "relay"
@@ -10,7 +10,7 @@ var pcConfigStatic = {
 
 var pcConfigDynamic = {
     "iceServers": [{
-        "url": "turn:turnserveruri:5349",
+        "urls": "turn:turnserveruri:5349",
         "credentialType": "password"
     }],
     "iceTransportPolicy": "relay"


### PR DESCRIPTION
:wave: hello!

The [RTCIcerServer object shape](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer) has changed recently, so I updated the config props in the Web Client Sample accordingly as the deprecated props were causing the server connection to fail. Thanks for the debugging help!

![bitmoji](https://render.bitstrips.com/v2/cpanel/7216901-209725411_3-s4-v1.png?transparent=1&palette=1&width=246)