### PR TITLE
Fixing firewall priority exceptions and TCP VM firewall rules

### DIFF
--- a/Samples/Server/Directx-Multithreaded/Deploy/WindowsVirtualMachine.json
+++ b/Samples/Server/Directx-Multithreaded/Deploy/WindowsVirtualMachine.json
@@ -232,7 +232,7 @@
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
-              "priority": 1030,
+              "priority": 1040,
               "direction": "Inbound"
             }
           },
@@ -245,7 +245,7 @@
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
-              "priority": 1040,
+              "priority": 1050,
               "direction": "Inbound"
             }
           }

--- a/Samples/Server/Directx-Multithreaded/Deploy/deploy-rendering-server.ps1
+++ b/Samples/Server/Directx-Multithreaded/Deploy/deploy-rendering-server.ps1
@@ -54,7 +54,7 @@ New-NetFirewallRule -DisplayName "3DStreamingServer" `
                     -EdgeTraversalPolicy Allow `
                     -Protocol TCP `
                     -LocalPort 80,443,3478,5349,19302 `
-                    -Program "($PathToExecutable + "\" + $ExeName)"
+                    -Program ($PathToExecutable + "\" + $ExeName)
 
 New-NetFirewallRule -DisplayName "3DStreamingServer" `
                     -Action Allow `

--- a/Samples/Server/Directx-SpinningCube/Deploy/WindowsVirtualMachine.json
+++ b/Samples/Server/Directx-SpinningCube/Deploy/WindowsVirtualMachine.json
@@ -232,7 +232,7 @@
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
-              "priority": 1030,
+              "priority": 1040,
               "direction": "Inbound"
             }
           },
@@ -245,7 +245,7 @@
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
-              "priority": 1040,
+              "priority": 1050,
               "direction": "Inbound"
             }
           }

--- a/Samples/Server/Directx-SpinningCube/Deploy/deploy-rendering-server.ps1
+++ b/Samples/Server/Directx-SpinningCube/Deploy/deploy-rendering-server.ps1
@@ -52,7 +52,7 @@ New-NetFirewallRule -DisplayName "3DStreamingServer" `
                     -EdgeTraversalPolicy Allow `
                     -Protocol TCP `
                     -LocalPort 80,443,3478,5349,19302 `
-                    -Program "($PathToExecutable + "\" + $ExeName)"
+                    -Program ($PathToExecutable + "\" + $ExeName)
 
 New-NetFirewallRule -DisplayName "3DStreamingServer" `
                     -Action Allow `


### PR DESCRIPTION
Fixes a couple of issues with the Azure server deployment projects for multithreaded and spinning cube