### PR TITLE
add critical comment

### DIFF
--- a/Plugins/UnityClientPlugin/WebRtcWrapper/Signalling/Conductor.cs
+++ b/Plugins/UnityClientPlugin/WebRtcWrapper/Signalling/Conductor.cs
@@ -612,6 +612,8 @@ namespace PeerConnectionClient.Signalling
             _signalingMode = RTCPeerConnectionSignalingMode.Json;
 #endif
             _signaller = new Signaller();
+
+            // if this is crashing with a FileNotFoundException it is because you are likely running in Debug. Please use Release.
             _media = Media.CreateMedia();
 
             Signaller.OnDisconnected += Signaller_OnDisconnected;


### PR DESCRIPTION
This comment makes it clear that when a developer (such as myself) is having __a time__ trying to run the UWP client, they should verify what build configuration they are using. 😅 