### PR TITLE
[bugfix] normalizes uri configuration key names

### DIFF
--- a/Libraries/ConfigParser/ConfigParser.Tests/ConfigParser.Tests.vcxproj
+++ b/Libraries/ConfigParser/ConfigParser.Tests/ConfigParser.Tests.vcxproj
@@ -106,7 +106,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\..\WebRTC\$(Platform)\$(Configuration)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)updatedWebrtcConfig.json" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -124,7 +124,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\..\WebRTC\$(Platform)\$(Configuration)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y $"(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)updatedWebrtcConfig.json" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -146,7 +146,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\..\WebRTC\$(Platform)\$(Configuration)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)updatedWebrtcConfig.json" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -168,7 +168,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\..\WebRTC\$(Platform)\$(Configuration)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)updatedWebrtcConfig.json" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Libraries/ConfigParser/ConfigParser.Tests/ConfigParser.Tests.vcxproj
+++ b/Libraries/ConfigParser/ConfigParser.Tests/ConfigParser.Tests.vcxproj
@@ -106,7 +106,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\..\WebRTC\$(Platform)\$(Configuration)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)updatedWebrtcConfig.json" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)dualWebrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)oldWebrtcConfig.json" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -124,7 +124,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\..\WebRTC\$(Platform)\$(Configuration)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)updatedWebrtcConfig.json" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)dualWebrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)oldWebrtcConfig.json" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -146,7 +146,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\..\WebRTC\$(Platform)\$(Configuration)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)updatedWebrtcConfig.json" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)dualWebrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)oldWebrtcConfig.json" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -168,7 +168,7 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\..\WebRTC\$(Platform)\$(Configuration)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)updatedWebrtcConfig.json" "$(OutDir)"</Command>
+      <Command>xcopy /y "$(ProjectDir)webrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)serverConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)dualWebrtcConfig.json" "$(OutDir)" &amp; xcopy /y "$(ProjectDir)oldWebrtcConfig.json" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Libraries/ConfigParser/ConfigParser.Tests/ConfigParserTests.cpp
+++ b/Libraries/ConfigParser/ConfigParser.Tests/ConfigParserTests.cpp
@@ -57,11 +57,11 @@ namespace ConfigParserTests
 			Assert::AreEqual("test:test:1234", injectedWebRTCInstance->turn_server.uri.c_str());
 			Assert::AreEqual("test", injectedWebRTCInstance->turn_server.username.c_str());
 			Assert::AreEqual("test", injectedWebRTCInstance->turn_server.password.c_str());
-			Assert::AreEqual("test", injectedWebRTCInstance->server.c_str());
+			Assert::AreEqual("test", injectedWebRTCInstance->server_uri.c_str());
 			Assert::IsTrue(((uint16_t)5678) == injectedWebRTCInstance->port);
 			Assert::IsTrue(((uint32_t)91011) == injectedWebRTCInstance->heartbeat);
 			Assert::AreEqual("test:test:1234", injectedWebRTCInstance->stun_server.uri.c_str());
-			Assert::AreEqual("test://test", injectedWebRTCInstance->authentication.authority.c_str());
+			Assert::AreEqual("test://test", injectedWebRTCInstance->authentication.authority_uri.c_str());
 			Assert::AreEqual("00000000-0000-0000-0000-000000000000", injectedWebRTCInstance->authentication.client_id.c_str());
 			Assert::AreEqual("test", injectedWebRTCInstance->authentication.client_secret.c_str());
 			Assert::AreEqual("test://test", injectedWebRTCInstance->authentication.code_uri.c_str());
@@ -73,11 +73,11 @@ namespace ConfigParserTests
 			Assert::AreEqual("", defaultWebRTCInstance->turn_server.uri.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->turn_server.username.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->turn_server.password.c_str());
-			Assert::AreEqual("", defaultWebRTCInstance->server.c_str());
+			Assert::AreEqual("", defaultWebRTCInstance->server_uri.c_str());
 			Assert::IsTrue(((uint16_t)0) == defaultWebRTCInstance->port);
 			Assert::IsTrue(((uint32_t)0) == defaultWebRTCInstance->heartbeat);
 			Assert::AreEqual("", defaultWebRTCInstance->stun_server.uri.c_str());
-			Assert::AreEqual("", defaultWebRTCInstance->authentication.authority.c_str());
+			Assert::AreEqual("", defaultWebRTCInstance->authentication.authority_uri.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->authentication.client_id.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->authentication.client_secret.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->authentication.code_uri.c_str());

--- a/Libraries/ConfigParser/ConfigParser.Tests/dualWebrtcConfig.json
+++ b/Libraries/ConfigParser/ConfigParser.Tests/dualWebrtcConfig.json
@@ -8,7 +8,7 @@
   "stunServer": {
     "uri": "test:test:1234"
   },
-    "server": "test",
+    "server":  "test",
     "serverUri":  "testUri",
     "port": 5678,
     "heartbeat": 91011,

--- a/Libraries/ConfigParser/ConfigParser.Tests/oldWebrtcConfig.json
+++ b/Libraries/ConfigParser/ConfigParser.Tests/oldWebrtcConfig.json
@@ -8,11 +8,11 @@
   "stunServer": {
     "uri": "test:test:1234"
   },
-    "serverUri":  "testUri",
+    "server": "test",
     "port": 5678,
     "heartbeat": 91011,
     "authentication": {
-        "authorityUri": "testUri://testUri",
+        "authority": "test://test",
         "clientId": "00000000-0000-0000-0000-000000000000",
         "clientSecret": "test",
         "codeUri": "test://test",

--- a/Libraries/ConfigParser/ConfigParser.Tests/updatedWebrtcConfig.json
+++ b/Libraries/ConfigParser/ConfigParser.Tests/updatedWebrtcConfig.json
@@ -9,10 +9,12 @@
     "uri": "test:test:1234"
   },
     "server": "test",
+    "serverUri":  "testUri",
     "port": 5678,
     "heartbeat": 91011,
     "authentication": {
         "authority": "test://test",
+        "authorityUri": "testUri://testUri",
         "clientId": "00000000-0000-0000-0000-000000000000",
         "clientSecret": "test",
         "codeUri": "test://test",

--- a/Libraries/ConfigParser/inc/config_parser.h
+++ b/Libraries/ConfigParser/inc/config_parser.h
@@ -23,7 +23,7 @@ namespace StreamingToolkit
 		/// <summary>
 		/// Represents the relative path at which we expect webrtcConfig to exist
 		/// </summary>
-		static const char* kWebrtcConfigPath;
+		///static const char* kWebrtcConfigPath;
 
 		/// <summary>
 		/// Represents the relative path at which we expect serverConfig to exist
@@ -64,7 +64,8 @@ namespace StreamingToolkit
 		/// instances of these types.
 		/// </remarks>
 		/// <param name="baseFilePath">a base path to look for configuration files in</param>
-		static void ConfigureConfigFactories(const std::string& baseFilePath);
+		/// <param name="webrtcConfigName"> the name of the webrtc Config file, defaults to "webrtcConfig.json"</param>
+		static void ConfigureConfigFactories(const std::string& baseFilePath, const std::string& webrtcConfigName= "webrtcConfig.json");
 
 		/// <summary>
 		/// Get the absolute path for a relative file

--- a/Libraries/ConfigParser/inc/structs.h
+++ b/Libraries/ConfigParser/inc/structs.h
@@ -68,7 +68,7 @@ namespace StreamingToolkit
 		std::string		uri;
 
 		/* The turn credential uri						*/
-		std::string		provider;
+		std::string		provider_uri;
 
 		/* The username used for authentication			*/
 		std::string		username;
@@ -92,7 +92,7 @@ namespace StreamingToolkit
 	typedef struct
 	{
 		/* The uri used for token retrieval				*/
-		std::string		authority;
+		std::string		authority_uri;
 
 		/*  OAuth 2.0 client credentials				*/
 		std::string		resource;
@@ -125,7 +125,7 @@ namespace StreamingToolkit
 		StunServer		stun_server;
 
 		/* The signaling server uri						*/
-		std::string		server;
+		std::string		server_uri;
 
 		/* The signaling server port					*/
 		uint16_t		port;

--- a/Libraries/ConfigParser/src/config_parser.cpp
+++ b/Libraries/ConfigParser/src/config_parser.cpp
@@ -79,10 +79,16 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 				webrtcConfig->turn_server.uri = turnServerNode.get("uri", NULL).asString();
 			}
 
-			if (turnServerNode.isMember("providerUri") || turnServerNode.isMember("provider"))
+			if (turnServerNode.isMember("providerUri"))
 			{
 				webrtcConfig->turn_server.provider_uri = turnServerNode.get("providerUri", NULL).asString();
 			}
+
+			if (turnServerNode.isMember("provider"))
+			{
+				webrtcConfig->turn_server.provider_uri = turnServerNode.get("provider", NULL).asString();
+			}
+
 
 			if (turnServerNode.isMember("username"))
 			{
@@ -104,10 +110,17 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 			}
 		}
 
-		if (root.isMember("serverUri")||root.isMember("server"))
+		if (root.isMember("serverUri"))
 		{
 			webrtcConfig->server_uri = root.get("serverUri", NULL).asString();
 		}
+
+
+		if (root.isMember("server"))
+		{
+			webrtcConfig->server_uri = root.get("server", NULL).asString();
+		}
+
 
 		if (root.isMember("port"))
 		{
@@ -122,10 +135,16 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 		if (root.isMember("authentication"))
 		{
 			auto authenticationNode = root.get("authentication", NULL);
-			if (authenticationNode.isMember("authorityUri") || authenticationNode.isMember("authority"))
+			if (authenticationNode.isMember("authorityUri"))
 			{
 				webrtcConfig->authentication.authority_uri = authenticationNode.get("authorityUri", NULL).asString();
 			}
+
+			if (authenticationNode.isMember("authority"))
+			{
+				webrtcConfig->authentication.authority_uri = authenticationNode.get("authority", NULL).asString();
+			}
+
 
 			if (authenticationNode.isMember("resource"))
 			{

--- a/Libraries/ConfigParser/src/config_parser.cpp
+++ b/Libraries/ConfigParser/src/config_parser.cpp
@@ -79,9 +79,9 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 				webrtcConfig->turn_server.uri = turnServerNode.get("uri", NULL).asString();
 			}
 
-			if (turnServerNode.isMember("provider"))
+			if (turnServerNode.isMember("providerUri"))
 			{
-				webrtcConfig->turn_server.provider = turnServerNode.get("provider", NULL).asString();
+				webrtcConfig->turn_server.provider_uri = turnServerNode.get("providerUri", NULL).asString();
 			}
 
 			if (turnServerNode.isMember("username"))
@@ -104,9 +104,9 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 			}
 		}
 
-		if (root.isMember("server"))
+		if (root.isMember("serverUri"))
 		{
-			webrtcConfig->server = root.get("server", NULL).asString();
+			webrtcConfig->server_uri = root.get("serverUri", NULL).asString();
 		}
 
 		if (root.isMember("port"))
@@ -122,9 +122,9 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 		if (root.isMember("authentication"))
 		{
 			auto authenticationNode = root.get("authentication", NULL);
-			if (authenticationNode.isMember("authority"))
+			if (authenticationNode.isMember("authorityUri"))
 			{
-				webrtcConfig->authentication.authority = authenticationNode.get("authority", NULL).asString();
+				webrtcConfig->authentication.authority_uri = authenticationNode.get("authorityUri", NULL).asString();
 			}
 
 			if (authenticationNode.isMember("resource"))

--- a/Libraries/ConfigParser/src/config_parser.cpp
+++ b/Libraries/ConfigParser/src/config_parser.cpp
@@ -79,7 +79,7 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 				webrtcConfig->turn_server.uri = turnServerNode.get("uri", NULL).asString();
 			}
 
-			if (turnServerNode.isMember("providerUri"))
+			if (turnServerNode.isMember("providerUri") || turnServerNode.isMember("provider"))
 			{
 				webrtcConfig->turn_server.provider_uri = turnServerNode.get("providerUri", NULL).asString();
 			}
@@ -104,7 +104,7 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 			}
 		}
 
-		if (root.isMember("serverUri"))
+		if (root.isMember("serverUri")||root.isMember("server"))
 		{
 			webrtcConfig->server_uri = root.get("serverUri", NULL).asString();
 		}
@@ -122,7 +122,7 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 		if (root.isMember("authentication"))
 		{
 			auto authenticationNode = root.get("authentication", NULL);
-			if (authenticationNode.isMember("authorityUri"))
+			if (authenticationNode.isMember("authorityUri") || authenticationNode.isMember("authority"))
 			{
 				webrtcConfig->authentication.authority_uri = authenticationNode.get("authorityUri", NULL).asString();
 			}

--- a/Libraries/ConfigParser/src/config_parser.cpp
+++ b/Libraries/ConfigParser/src/config_parser.cpp
@@ -9,7 +9,7 @@
 
 using namespace StreamingToolkit;
 
-const char* ConfigParser::kWebrtcConfigPath = "webrtcConfig.json";
+///const char* ConfigParser::kWebrtcConfigPath = "webrtcConfig.json";
 const char* ConfigParser::kServerConfigPath = "serverConfig.json";
 const char* ConfigParser::kNvEncConfigPath = "nvEncConfig.json";
 
@@ -26,12 +26,12 @@ void ConfigParser::ConfigureConfigFactories()
 	ConfigureConfigFactories(GetAbsolutePath(""));
 }
 
-void ConfigParser::ConfigureConfigFactories(const std::string& baseFilePath)
+void ConfigParser::ConfigureConfigFactories(const std::string& baseFilePath, const std::string& webrtcConfigName)
 {
 	CppFactory::Object<StreamingToolkit::WebRTCConfig>::RegisterAllocator([=] {
 		auto config = new StreamingToolkit::WebRTCConfig();
 
-		ConfigParser::ParseWebRTCConfig(baseFilePath + std::string(ConfigParser::kWebrtcConfigPath), config);
+		ConfigParser::ParseWebRTCConfig(baseFilePath + webrtcConfigName, config);
 
 		return std::shared_ptr<StreamingToolkit::WebRTCConfig>(config);
 	});
@@ -79,15 +79,17 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 				webrtcConfig->turn_server.uri = turnServerNode.get("uri", NULL).asString();
 			}
 
+			if (turnServerNode.isMember("provider"))
+			{
+				webrtcConfig->turn_server.provider_uri = turnServerNode.get("provider", NULL).asString();
+			}
+
+
 			if (turnServerNode.isMember("providerUri"))
 			{
 				webrtcConfig->turn_server.provider_uri = turnServerNode.get("providerUri", NULL).asString();
 			}
 
-			if (turnServerNode.isMember("provider"))
-			{
-				webrtcConfig->turn_server.provider_uri = turnServerNode.get("provider", NULL).asString();
-			}
 
 
 			if (turnServerNode.isMember("username"))
@@ -110,18 +112,18 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 			}
 		}
 
-		if (root.isMember("serverUri"))
-		{
-			webrtcConfig->server_uri = root.get("serverUri", NULL).asString();
-		}
-
-
 		if (root.isMember("server"))
 		{
 			webrtcConfig->server_uri = root.get("server", NULL).asString();
 		}
 
 
+		if (root.isMember("serverUri"))
+		{
+			webrtcConfig->server_uri = root.get("serverUri", NULL).asString();
+		}
+
+		
 		if (root.isMember("port"))
 		{
 			webrtcConfig->port = root.get("port", NULL).asInt();
@@ -135,16 +137,15 @@ void ConfigParser::ParseWebRTCConfig(const std::string& path, StreamingToolkit::
 		if (root.isMember("authentication"))
 		{
 			auto authenticationNode = root.get("authentication", NULL);
-			if (authenticationNode.isMember("authorityUri"))
-			{
-				webrtcConfig->authentication.authority_uri = authenticationNode.get("authorityUri", NULL).asString();
-			}
-
 			if (authenticationNode.isMember("authority"))
 			{
 				webrtcConfig->authentication.authority_uri = authenticationNode.get("authority", NULL).asString();
 			}
 
+			if (authenticationNode.isMember("authorityUri"))
+			{
+				webrtcConfig->authentication.authority_uri = authenticationNode.get("authorityUri", NULL).asString();
+			}
 
 			if (authenticationNode.isMember("resource"))
 			{

--- a/Plugins/NativeServerPlugin/src/multi_peer_conductor.cpp
+++ b/Plugins/NativeServerPlugin/src/multi_peer_conductor.cpp
@@ -45,7 +45,7 @@ PeerConnectionClient& MultiPeerConductor::PeerConnection()
 
 void MultiPeerConductor::ConnectSignallingAsync(const string& client_name)
 {
-	signalling_client_.Connect(config_->webrtc_config->server,
+	signalling_client_.Connect(config_->webrtc_config->server_uri,
 		config_->webrtc_config->port,
 		client_name);
 }

--- a/Plugins/NativeServerPlugin/webrtcConfig.json
+++ b/Plugins/NativeServerPlugin/webrtcConfig.json
@@ -5,11 +5,11 @@
     "username": "username",
     "password": "password"
   },
-  "server": "https://signalingserveruri",
+  "serverUri": "https://signalingserveruri",
   "port": 443,
   "heartbeat": 5000,
   "authentication": {
-    "authority": "https://aadauthorityuri",
+    "authorityUri": "https://aadauthorityuri",
     "resource": "00000000-0000-0000-0000-000000000000",
     "clientId": "00000000-0000-0000-0000-000000000000",
     "clientSecret": "aadsecretstring"

--- a/Plugins/UnityServerPlugin/StreamingUnityServerPlugin.cpp
+++ b/Plugins/UnityServerPlugin/StreamingUnityServerPlugin.cpp
@@ -271,7 +271,7 @@ void InitWebRTC()
 	// Initializes SSL.
 	rtc::InitializeSSL();
 		
-	s_server = fullServerConfig->webrtc_config->server;
+	s_server = fullServerConfig->webrtc_config->server_uri;
 	s_port = fullServerConfig->webrtc_config->port;
 
 	// Initializes the conductor.

--- a/Samples/Client/DirectxWin32/src/main.cpp
+++ b/Samples/Client/DirectxWin32/src/main.cpp
@@ -53,7 +53,7 @@ int WINAPI wWinMain(
 	rtc::ThreadManager::Instance()->SetCurrentThread(&w32_thread);
 
 	ClientMainWindow wnd(
-		webrtcConfig->server.c_str(),
+		webrtcConfig->server_uri.c_str(),
 		webrtcConfig->port,
 		FLAG_autoconnect,
 		FLAG_autocall,
@@ -86,10 +86,10 @@ int WINAPI wWinMain(
 	std::unique_ptr<TurnCredentialProvider> turn;
 
 	if (oauth.get() != nullptr &&
-		webrtcConfig->turn_server.provider != FLAG_turnUri &&
-		!webrtcConfig->turn_server.provider.empty())
+		webrtcConfig->turn_server.provider_uri != FLAG_turnUri &&
+		!webrtcConfig->turn_server.provider_uri.empty())
 	{
-		turn.reset(new TurnCredentialProvider(webrtcConfig->turn_server.provider));
+		turn.reset(new TurnCredentialProvider(webrtcConfig->turn_server.provider_uri));
 	}
 
 	PeerConnectionClient client;

--- a/Samples/Server/Directx-Multithreaded/Multithreaded.cpp
+++ b/Samples/Server/Directx-Multithreaded/Multithreaded.cpp
@@ -565,7 +565,7 @@ bool AppMain(BOOL stopping)
 	rtc::ThreadManager::Instance()->SetCurrentThread(&w32_thread);
 
 	ServerMainWindow wnd(
-		fullServerConfig->webrtc_config->server.c_str(),
+		fullServerConfig->webrtc_config->server_uri.c_str(),
 		fullServerConfig->webrtc_config->port,
 		fullServerConfig->server_config->server_config.auto_connect,
 		fullServerConfig->server_config->server_config.auto_call,
@@ -811,7 +811,7 @@ bool AppMain(BOOL stopping)
 	// For system service, automatically connect to the signaling server.
 	if (fullServerConfig->server_config->server_config.system_service)
 	{
-		cond.StartLogin(fullServerConfig->webrtc_config->server.c_str(),
+		cond.StartLogin(fullServerConfig->webrtc_config->server_uri.c_str(),
 			fullServerConfig->webrtc_config->port);
 	}
 

--- a/Samples/Server/Directx-SpinningCube/App.cpp
+++ b/Samples/Server/Directx-SpinningCube/App.cpp
@@ -174,7 +174,7 @@ bool AppMain(BOOL stopping)
 	rtc::ThreadManager::Instance()->SetCurrentThread(&w32_thread);
 
 	ServerMainWindow wnd(
-		fullServerConfig->webrtc_config->server.c_str(),
+		fullServerConfig->webrtc_config->server_uri.c_str(),
 		fullServerConfig->webrtc_config->port,
 		fullServerConfig->server_config->server_config.auto_connect,
 		fullServerConfig->server_config->server_config.auto_call,
@@ -405,7 +405,7 @@ bool AppMain(BOOL stopping)
 	// For system service, automatically connect to the signaling server.
 	if (fullServerConfig->server_config->server_config.system_service)
 	{
-		cond.StartLogin(fullServerConfig->webrtc_config->server.c_str(),
+		cond.StartLogin(fullServerConfig->webrtc_config->server_uri.c_str(),
 			fullServerConfig->webrtc_config->port);
 	}
 

--- a/Samples/Server/OpenGL-SpinningCube/App.cpp
+++ b/Samples/Server/OpenGL-SpinningCube/App.cpp
@@ -201,7 +201,7 @@ bool AppMain(BOOL stopping)
 	rtc::ThreadManager::Instance()->SetCurrentThread(&w32_thread);
 
 	ServerMainWindow wnd(
-		fullServerConfig->webrtc_config->server.c_str(),
+		fullServerConfig->webrtc_config->server_uri.c_str(),
 		fullServerConfig->webrtc_config->port,
 		fullServerConfig->server_config->server_config.auto_connect,
 		fullServerConfig->server_config->server_config.auto_call,


### PR DESCRIPTION
Changed all the names to reflect whether or not they are URI's. Specifically changed the following in structs.h and everywhere else that is relevant:

1. `TurnServer.provider -> TurnServer.provider_uri`
2. `Authentication.authority -> Authentication.authority_uri`
3. `WebRTCConfig.server -> WebRTCConfig.server_uri`  


fixes #81